### PR TITLE
Fix preload links so they actually work.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,16 +6,22 @@
             rel="preload"
             href="static/media/roboto-latin-400.479970ff.woff2"
             as="font"
+            type="font/woff2"
+            crossorigin
         />
         <link
             rel="preload"
             href="static/media/roboto-latin-500.020c97dc.woff2"
             as="font"
+            type="font/woff2"
+            crossorigin
         />
         <link
             rel="preload"
             href="static/media/roboto-latin-700.2735a3a6.woff2"
             as="font"
+            type="font/woff2"
+            crossorigin
         />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
         <meta


### PR DESCRIPTION
Without these attributes, particularly the crossorigin one, the resources preload and then load again when needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/36)
<!-- Reviewable:end -->
