### PR TITLE
Fix BookshelfChooser to set key instead of englishName

### DIFF
--- a/src/components/Admin/BookshelfChooser.tsx
+++ b/src/components/Admin/BookshelfChooser.tsx
@@ -36,8 +36,8 @@ export const BookshelfChooser: React.FunctionComponent<{
                 backspaceRemovesValue={false}
                 isClearable={false} // don't need the extra "x"
                 options={matchingBookshelves.map(b => ({
-                    value: b.englishName,
-                    label: b.key
+                    value: b.key,
+                    label: b.englishName
                 }))}
                 value={chosenBookshelfKeys.map(b => ({
                     value: b,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/63)
<!-- Reviewable:end -->
