### PR TITLE
Redirect Urls mentioning covid19, and searches for covid19 terms

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -8,6 +8,7 @@ import {
     restoreScrollPosition,
     storeScrollPosition,
 } from "./RestoreScrollPosition";
+import { CheckForCovidSearch } from "./components/SearchBox";
 
 export interface ILocation {
     // this is used only when the location is a book detail
@@ -52,7 +53,13 @@ export class Router {
         const specialPage = specialPages.find(
             (s) => "/" + s === window.location.pathname
         );
-        if (specialPage) {
+        if (CheckForCovidSearch(window.location.search)) {
+            this.push({
+                title: "",
+                pageType: "Covid19",
+                filter: {},
+            });
+        } else if (specialPage) {
             this.push(home);
             this.push({
                 title: specialPage,

--- a/src/components/ByLanguageGroups.tsx
+++ b/src/components/ByLanguageGroups.tsx
@@ -64,7 +64,11 @@ export const ByLanguageGroups: React.FunctionComponent<{
         setRows(newRows);
         setTotalBookCount(totalCount);
     }, [
-        searchResults.books,
+        // Including this:
+        //   searchResults.books,
+        // leads to an infinite loop that I haven't been able to figure out
+        // You get it by typing "covid" into search, which then redirect to this page.
+        // We can get away without it because the books.length will change when the query comes back
         searchResults.books.length,
         reportBooksAndLanguages,
     ]);

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -86,11 +86,23 @@ export const SearchBox: React.FunctionComponent<{
         ) {
             giveFreeLearningCsv();
             return;
-        } // shortcut to grid
+        }
+        // enhance: we should just have a set of these keyword-->special page searches, not code for each.
+
+        // shortcut to grid
         if (searchString.toLowerCase() === "grid") {
             router!.push({
                 title: `Grid`,
                 pageType: "grid",
+                filter: {},
+            });
+            setSearchString("");
+            return;
+        }
+        if (CheckForCovidSearch(searchString)) {
+            router!.push({
+                title: "",
+                pageType: "Covid19",
                 filter: {},
             });
             setSearchString("");
@@ -202,3 +214,11 @@ export const SearchBox: React.FunctionComponent<{
         searchTextField
     );
 };
+
+export function CheckForCovidSearch(search?: string) {
+    if (!search) return false;
+    const searchTerms = search.toLowerCase();
+    return (
+        searchTerms.indexOf("covid") > -1 || searchTerms.indexOf("corona") > -1
+    );
+}


### PR DESCRIPTION
Trade-off: This does make it impossible to do compound searches using covid-19 for now, like you could not search for "covid-19 language:foo".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/73)
<!-- Reviewable:end -->
