### PR TITLE
Make license IDs for Free Learning CSV conform to SPDX

### DIFF
--- a/src/export/freeLearningIO.ts
+++ b/src/export/freeLearningIO.ts
@@ -141,7 +141,7 @@ function fields(book: Book, isoCode: string): Array<string | undefined> {
             book.getBestLevel() || "", // book.getTagValue("computedLevel") || "", //
             book.uploadDate?.toISOString() || "",
             book.publisher || "",
-            book.license || "Unknown License",
+            book.license.toUpperCase() + "-4.0", // SPDX requires this
             `https://bloomlibrary.org/readBook/${book.id}?bookLang=${isoCode}`,
             valueForEpubLine,
         ];


### PR DESCRIPTION
Means adding a version. Since our License page refers people to version 4.0 of CC, I think it's fair to assume that's the version they are providing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/143)
<!-- Reviewable:end -->
