### PR TITLE
Fix a bug in DetailView's use of hooks

### DIFF
--- a/src/components/BookDetail/ArtifactGroup.tsx
+++ b/src/components/BookDetail/ArtifactGroup.tsx
@@ -144,8 +144,10 @@ export const ArtifactGroup: React.FunctionComponent<{
                                 key={a.alt}
                                 aria-label={`${a.alt} is not available`}
                                 title={
-                                    a.settings?.reasonForHiding(props.book) ||
-                                    a.alt
+                                    a.settings?.reasonForHiding(
+                                        props.book,
+                                        l10n
+                                    ) || a.alt
                                 }
                                 arrow={true}
                             >

--- a/src/model/ArtifactVisibilitySettings.ts
+++ b/src/model/ArtifactVisibilitySettings.ts
@@ -1,6 +1,6 @@
 import { observable, computed } from "mobx";
 import { Book } from "../model/Book";
-import { useIntl } from "react-intl";
+import { useIntl, IntlShape } from "react-intl";
 
 // This is related to the "show" column on book in ParseServer
 export class ArtifactVisibilitySettings {
@@ -50,20 +50,18 @@ export class ArtifactVisibilitySettings {
         return this.user !== undefined;
     };
 
-    private l10n = useIntl();
-
     // returns undefined if it's not hidden and should be available
-    public reasonForHiding(book: Book): string | undefined {
+    public reasonForHiding(book: Book, l10n: IntlShape): string | undefined {
         switch (book.harvestState) {
             case "Updated":
             case "New":
-                return this.l10n.formatMessage({
+                return l10n.formatMessage({
                     id: "book.artifacts.visibility.new",
                     defaultMessage:
                         "Our system has not yet generated this format.",
                 });
             case "Failed":
-                return this.l10n.formatMessage({
+                return l10n.formatMessage({
                     id: "book.artifacts.visibility.fail",
                     defaultMessage:
                         "Our system ran into a problem while trying to generate this format.",
@@ -71,19 +69,19 @@ export class ArtifactVisibilitySettings {
             case "Done":
                 return (
                     (this.isUserHide() &&
-                        this.l10n.formatMessage({
+                        l10n.formatMessage({
                             id: "book.artifacts.visibility.userHidden",
                             defaultMessage:
                                 "This format has been hidden by the person who uploaded this book.",
                         })) ||
                     (this.isLibrarianHide() &&
-                        this.l10n.formatMessage({
+                        l10n.formatMessage({
                             id: "book.artifacts.visibility.librarianHidden",
                             defaultMessage:
                                 "This format has been hidden by a site moderator.",
                         })) ||
                     (this.isHarvesterHide() &&
-                        this.l10n.formatMessage({
+                        l10n.formatMessage({
                             id: "book.artifacts.visibility.scaling",
                             defaultMessage:
                                 "Our system was not confident about scaling the book to this format.",


### PR DESCRIPTION
Conditional creation of settings objects could break the rules with bad results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/147)
<!-- Reviewable:end -->
