### PR TITLE
Fix bloom-player iframe url for upcoming changes (BL-8874)

### DIFF
--- a/src/components/ReadBookPage.tsx
+++ b/src/components/ReadBookPage.tsx
@@ -163,7 +163,9 @@ export const ReadBookPage: React.FunctionComponent<{
     // Here, it does not 'go back' but pushes the detail view as a new history entry.)
     const showBackButton = previousPathname.indexOf(`/book/${id}`) < 0;
 
-    const iframeSrc = `${bloomPlayerUrl}?url=${url}&showBackButton=${showBackButton}&centerVertically=false&useOriginalPageSize=true${langParam}&hideFullScreenButton=${autoFullScreen}`;
+    const iframeSrc =
+        `${bloomPlayerUrl}?url=${url}&showBackButton=${showBackButton}&centerVertically=false&useOriginalPageSize=true` +
+        `${langParam}&hideFullScreenButton=${autoFullScreen}&independent=false&host=bloomlibrary`;
 
     // This theme matches Bloom-player. It is supposed to help the full-screen button
     // better match the Bloom-player icons, whose toolbar it overlays. Not successful


### PR DESCRIPTION
This change will keep bloom-player from interfering with Bloom Library sending analytics when the change is made for bloom-player to send its own analytics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/156)
<!-- Reviewable:end -->
