### PR TITLE
Force a default tag prefix "tag:" is user doesn't give one (BL-8990)

### DIFF
--- a/src/components/Admin/StaffMultiChoosers.tsx
+++ b/src/components/Admin/StaffMultiChoosers.tsx
@@ -125,7 +125,16 @@ export const TagsChooser: React.FunctionComponent<{
                     .sort()
             }
             setSelectedValues={(items: string[]) => {
-                props.book.tags = items;
+                // Force a default prefix of "tag:" if the user does not provide one.
+                // Otherwise, the prefix will default to "topic:", which isn't necessarily wanted.
+                // See https://issues.bloomlibrary.org/youtrack/issue/BL-8990.
+                const xitems = items.map(item => {
+                    if (item.includes(":")) {
+                        return item;
+                    }
+                    return "tag:" + item;
+                })
+                props.book.tags = xitems;
             }}
             getStylingForValue={(t: string) => {
                 const defaultStyle = {

--- a/src/components/BulkEdit/BulkChangeFunctions.ts
+++ b/src/components/BulkEdit/BulkChangeFunctions.ts
@@ -46,6 +46,15 @@ export async function AddTagAllBooksInFilter(
     newTag: string,
     refresh: () => void
 ) {
+    if (!newTag.includes(":")) {
+        // Provide a default prefix if none is provided.  Otherwise a "topic" prefix is
+        // chosen for us.  See https://issues.bloomlibrary.org/youtrack/issue/BL-8990.
+        if (newTag.startsWith("-")) {
+            newTag = "-tag:" + newTag.substr(1);
+        } else {
+            newTag = "tag:" + newTag;
+        }
+    }
     const finalParams = constructParseBookQuery({}, filter, CachedTables.tags);
     const headers = getConnection().headers;
     const books = await axios.get(`${getConnection().url}classes/books`, {

--- a/src/connection/ParseServerConnection.ts
+++ b/src/connection/ParseServerConnection.ts
@@ -44,6 +44,11 @@ export function getConnection(): IConnection {
         // change to true when testing with local database
         return local;
     }
+    if (false && // Change to true to test localhost:3000 with dev instead of prod
+        window.location.hostname === "localhost" &&
+        window.location.port === "3000") {
+        return dev;
+        }
     if (
         window.location.hostname === "bloomlibrary.org" ||
         window.location.hostname === "next.bloomlibrary.org" ||


### PR DESCRIPTION
Old versions of Bloom before 3.8 (notably, REACH) did not prefix topic
tags.  If users add a plain tag string, we don't want to assume that a
topic tag is wanted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/176)
<!-- Reviewable:end -->
