### PR TITLE
Allow contentful links to open external links

### DIFF
--- a/src/components/BlorgLink.tsx
+++ b/src/components/BlorgLink.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { Link, LinkProps } from "react-router-dom";
+
+// for a discussion around how react-router link doesn't handle
+// external links, see https://github.com/ReactTraining/react-router/issues/1147
+
+export const BlorgLink: React.FunctionComponent<LinkProps> = (props) => {
+    return isExternal(props.to as string) ? (
+        <a
+            href={props.to as string}
+            target={"_blank"}
+            rel="noopener noreferrer"
+            {...props}
+        >
+            {props.children}
+        </a>
+    ) : (
+        <Link {...props} />
+    );
+};
+
+function isExternal(url: string): boolean {
+    try {
+        // if it doesn't start with http, let's say it is internal
+        if (!url.startsWith("http")) return false;
+        // if it does, it could still be pointing to this site
+        const urlObj = new URL(url, window.location.origin);
+        return urlObj.hostname !== window.location.hostname;
+    } catch {
+        console.error(`isExternal() could not parse ${url}`);
+        return false;
+    }
+}

--- a/src/components/CheapCard.tsx
+++ b/src/components/CheapCard.tsx
@@ -6,7 +6,7 @@ import { jsx } from "@emotion/core";
 import React from "react";
 import { commonUI } from "../theme";
 import { getUrlForTarget } from "./Routes";
-import { Link } from "react-router-dom";
+import { BlorgLink } from "./BlorgLink";
 
 interface IProps extends React.HTMLProps<HTMLDivElement> {
     className?: string;
@@ -19,7 +19,7 @@ interface IProps extends React.HTMLProps<HTMLDivElement> {
 export const CheapCard: React.FunctionComponent<IProps> = (props) => {
     const url = getUrlForTarget(props.target || "");
     return (
-        <Link
+        <BlorgLink
             //{...props}
             className={`cheapCard ${props.className}`}
             css={css`
@@ -61,10 +61,10 @@ export const CheapCard: React.FunctionComponent<IProps> = (props) => {
                     color: black;
                 }
             `}
-            to={`/${url}`}
+            to={url}
             role={props.role}
         >
             {props.children}
-        </Link>
+        </BlorgLink>
     );
 };

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -60,9 +60,7 @@ export const Routes: React.FunctionComponent<{}> = () => {
                 >
                     <Redirect to="/page/create/downloads" />
                 </Route>
-                <Route
-                    path={"/page/create/about"}
-                >
+                <Route path={"/page/create/about"}>
                     <ContentfulMultiPartPage urlKey="new-about" />
                 </Route>
                 <Route
@@ -297,6 +295,8 @@ export function splitPathname(
 // See https://docs.google.com/document/d/1cA9-9tMSydZ6Euo-hKmdHo_JlO0aLW8Fi9v293oIHK0/edit#heading=h.3b7gegy9uie8
 // for more of the logic.
 export function getUrlForTarget(target: string) {
+    if (target.startsWith("http")) return target;
+
     const {
         embeddedSettingsUrlKey,
         breadcrumbs,

--- a/src/components/RowOfCards.tsx
+++ b/src/components/RowOfCards.tsx
@@ -45,9 +45,9 @@ const RowOfCardsInternal: React.FunctionComponent<{
     const childCollections = props.collection.childCollections;
     const cards: JSX.Element[] = childCollections.map((childCollection1) => {
         const childCollection = childCollection1!; // can't persuade typescript that this can't be null.
-        const key =
+        const target =
             childCollection.type === "page"
-                ? `page/${childCollection!.urlKey}`
+                ? `/page/${childCollection!.urlKey}`
                 : childCollection!.urlKey;
 
         switch (props.collection.layout) {
@@ -62,7 +62,7 @@ const RowOfCardsInternal: React.FunctionComponent<{
                                 ? "short"
                                 : undefined
                         }
-                        key={key}
+                        key={target}
                         title={childCollection.label || ""}
                         richTextLabel={childCollection.richTextLabel}
                         hideTitle={
@@ -70,7 +70,7 @@ const RowOfCardsInternal: React.FunctionComponent<{
                         }
                         bookCount="??"
                         filter={childCollection.filter}
-                        target={`/${key}`}
+                        target={target}
                         //pageType={props.bookShelfCategory}
                         imageUrl={
                             childCollection.iconForCardAndDefaultBanner?.url ||

--- a/src/model/ContentInterfaces.ts
+++ b/src/model/ContentInterfaces.ts
@@ -41,7 +41,7 @@ export interface ICollection {
     iconAltText?: string;
     hideLabelOnCardAndDefaultBanner?: boolean;
     childCollections: ICollection[]; // only the top level will have these
-    type: "collection" | "page";
+    type: "collection" | "page" |"link";
     // When the filter cannot be fully defined as simple json in a Contentful collection (interpreted by ParseServer).
     // E.g., we need to run code like getBestLevelStringOrEmpty() to get at the filter
     secondaryFilter?: (basicBookInfo: IBasicBookInfo) => boolean;

--- a/src/model/Contentful.ts
+++ b/src/model/Contentful.ts
@@ -68,7 +68,7 @@ export function convertContentfulCollectionToICollection(
         layout: item.fields.layout?.fields?.name || "by-level",
         rows: item.fields.rows,
         order,
-        type: item.sys.contentType.sys.id,
+        type: item.fields.urlKey.startsWith("http") ? "link" : item.sys.contentType.sys.id,
     };
     return result;
 }


### PR DESCRIPTION
Use the React-Router link if the target is internal, otherwise use a `<a>` that opens a new tab.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/206)
<!-- Reviewable:end -->
