### PR TITLE
Some tweaks around how we decide which form of a language name to show

### DIFF
--- a/src/components/ByLanguageGroups.tsx
+++ b/src/components/ByLanguageGroups.tsx
@@ -93,10 +93,8 @@ export const ByLanguageGroups: React.FunctionComponent<{
                     } else return true;
                 })
                 .sort((x, y) =>
-                    getDisplayNamesForLanguage(
-                        x
-                    ).displayNameWithAutonym.localeCompare(
-                        getDisplayNamesForLanguage(y).displayNameWithAutonym
+                    getDisplayNamesForLanguage(x).combined.localeCompare(
+                        getDisplayNamesForLanguage(y).combined
                     )
                 ),
         [languagesByBookCount, props.excludeLanguages]
@@ -116,7 +114,7 @@ export const ByLanguageGroups: React.FunctionComponent<{
                     <BookGroup
                         key={l.isoCode}
                         title={`${props.titlePrefix} ${
-                            getDisplayNamesForLanguage(l).displayNameWithAutonym
+                            getDisplayNamesForLanguage(l).combined
                         }`}
                         predeterminedBooks={books}
                         contextLangIso={l.isoCode}

--- a/src/components/LanguageCard.tsx
+++ b/src/components/LanguageCard.tsx
@@ -29,14 +29,7 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
         ...propsToPassDown
     } = props; // Prevent React warnings
     const cardPadding = "14px";
-    const { displayName: languageName, autonym } = getDisplayNamesForLanguage(
-        props
-    );
-    const languageCodeAndAlternateName = (props.isoCode.indexOf("-") > -1 &&
-    props.isoCode !== props.englishName
-        ? [props.isoCode, autonym]
-        : [autonym]
-    ).join(" ");
+    const { primary, secondary } = getDisplayNamesForLanguage(props);
 
     return (
         <CheapCard
@@ -66,7 +59,7 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
                         color: ${commonUI.colors.minContrastGray};
                     `}
                 >
-                    {languageCodeAndAlternateName}
+                    {secondary}
                 </div>
             </div>
             <h2
@@ -83,7 +76,7 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
                     // test false positives css={css`color: red;`}
                     lines={2}
                 >
-                    <span> {languageName} </span>
+                    <span> {primary} </span>
                 </TruncateMarkup>
             </h2>
             <div

--- a/src/components/LanguageFeatureList.tsx
+++ b/src/components/LanguageFeatureList.tsx
@@ -37,8 +37,8 @@ export const LanguageFeatureList: React.FunctionComponent<IProps> = (props) => {
             const languageDisplayNames = getDisplayNamesForLanguage(language);
             languageElements.push(
                 showOneNamePerLanguage
-                    ? languageDisplayNames.displayName
-                    : languageDisplayNames.displayNameWithAutonym
+                    ? languageDisplayNames.primary
+                    : languageDisplayNames.combined
             );
 
             // Looking for features that the book has with this language code attached,

--- a/src/components/LanguageGroup.tsx
+++ b/src/components/LanguageGroup.tsx
@@ -6,7 +6,11 @@ import { jsx } from "@emotion/core";
 
 import React, { useContext, useState } from "react";
 import { LanguageCard } from "./LanguageCard";
-import Downshift, { GetItemPropsOptions, GetMenuPropsOptions, GetRootPropsOptions } from "downshift";
+import Downshift, {
+    GetItemPropsOptions,
+    GetMenuPropsOptions,
+    GetRootPropsOptions,
+} from "downshift";
 import matchSorter from "match-sorter";
 import searchIcon from "../search.png";
 import { CachedTablesContext } from "../App";
@@ -41,24 +45,24 @@ export const LanguageGroup: React.FunctionComponent = () => {
         if (filteredLanguages.length) {
             return (
                 <div {...getMenuProps({})}>
-                <CardSwiper>
-                    {filteredLanguages.map((l: any, index: number) => (
-                        // JohnnT: I think this comment is wrong; getLabelProps is actually to do with a label for
-                        // the whole chooser.
-                        // TODO: to complete the accessibility, we need to pass the Downshift getLabelProps into LanguageCard
-                        // and apply it to the actual label.
-                        <LanguageCard
-                            {...getItemProps({ item: l })}
-                            key={index}
-                            name={l.name}
-                            englishName={l.englishName}
-                            usageCount={l.usageCount}
-                            isoCode={l.isoCode}
-                            objectId={l.objectId}
-                            role="option"
-                        />
-                    ))}
-                </CardSwiper>
+                    <CardSwiper>
+                        {filteredLanguages.map((l: any, index: number) => (
+                            // JohnnT: I think this comment is wrong; getLabelProps is actually to do with a label for
+                            // the whole chooser.
+                            // TODO: to complete the accessibility, we need to pass the Downshift getLabelProps into LanguageCard
+                            // and apply it to the actual label.
+                            <LanguageCard
+                                {...getItemProps({ item: l })}
+                                key={index}
+                                name={l.name}
+                                englishName={l.englishName}
+                                usageCount={l.usageCount}
+                                isoCode={l.isoCode}
+                                objectId={l.objectId}
+                                role="option"
+                            />
+                        ))}
+                    </CardSwiper>
                 </div>
             );
         } else {
@@ -93,7 +97,7 @@ export const LanguageGroup: React.FunctionComponent = () => {
     // is allowed to have a role property. The effect is to prevent the root div that contains
     // the type-ahead box getting the combobox role and related aria declarations that cause
     // NVDA to skip it in browse mode (no, I don't know why it would skip combo boxes!  )
-    const rootPropsOptions:GetRootPropsOptions = {refKey:"ref"};
+    const rootPropsOptions: GetRootPropsOptions = { refKey: "ref" };
     (rootPropsOptions as any).role = undefined;
 
     return langChosen ? (
@@ -110,7 +114,8 @@ export const LanguageGroup: React.FunctionComponent = () => {
                 // This has an ID to match the aria-labelledby above.
                 // The FormattedMessage has an ID to look up the message, but its ID does not
                 // appear in the generated document so there is no confusion.
-                id="findBooksByLanguage">
+                id="findBooksByLanguage"
+            >
                 <FormattedMessage
                     id="findBooksByLanguage"
                     defaultMessage="Find Books By Language"
@@ -122,8 +127,14 @@ export const LanguageGroup: React.FunctionComponent = () => {
                 It also claims to present it all in a WAI-ARIA compliant accessible way (untested).
                 We give it a function that returns a react element that contains the
                 list of matching cards, and it calls that function on every keystroke. */
-                <Downshift getA11yStatusMessage={({resultCount})=>resultCount? `${resultCount} results. Use tab and shift-tab to navigate`: "No results found"}
-                defaultIsOpen={true}>
+                <Downshift
+                    getA11yStatusMessage={({ resultCount }) =>
+                        resultCount
+                            ? `${resultCount} results. Use tab and shift-tab to navigate`
+                            : "No results found"
+                    }
+                    defaultIsOpen={true}
+                >
                     {({
                         getInputProps,
                         getLabelProps,
@@ -152,12 +163,15 @@ export const LanguageGroup: React.FunctionComponent = () => {
                                     `}
                                 >
                                     <div
-                                    // downshift insists there must be a label. We don't want to see it, but do want a screen
-                                    // reader to find it, so hide it off screen.
-                                    css={css`${propsToHideAccessibilityElement}`}
-                                     {...getLabelProps()}>
-                                         enter partial language name
-                                     </div>
+                                        // downshift insists there must be a label. We don't want to see it, but do want a screen
+                                        // reader to find it, so hide it off screen.
+                                        css={css`
+                                            ${propsToHideAccessibilityElement}
+                                        `}
+                                        {...getLabelProps()}
+                                    >
+                                        enter partial language name
+                                    </div>
                                     <input
                                         css={css`
                                             display: block;
@@ -197,7 +211,8 @@ export const LanguageGroup: React.FunctionComponent = () => {
                             </div>
                             {getFilterLanguagesUI(
                                 currentInputBoxText,
-                                getItemProps, getMenuProps
+                                getItemProps,
+                                getMenuProps
                             )}
                         </div>
                     )}

--- a/src/components/LanguageLink.tsx
+++ b/src/components/LanguageLink.tsx
@@ -44,5 +44,5 @@ export function getLanguageNames(languages: ILanguage[]): string[] {
 // For languages where the name differs in English, we are currently
 // showing the autonym followed by English in parentheses.
 export function getNameDisplay(l: ILanguage) {
-    return getDisplayNamesForLanguage(l).displayNameWithAutonym;
+    return getDisplayNamesForLanguage(l).combined;
 }

--- a/src/components/statistics/BookStatsReport.tsx
+++ b/src/components/statistics/BookStatsReport.tsx
@@ -34,7 +34,7 @@ export const BookStatsReport: React.FunctionComponent<IStatsProps> = (
             const languageDisplayName = getDisplayNamesFromLanguageCode(
                 stat.language,
                 languages
-            )?.displayNameWithAutonym;
+            )?.combined;
             if (languageDisplayName) {
                 stat.language = languageDisplayName;
             }

--- a/src/model/Collections.tsx
+++ b/src/model/Collections.tsx
@@ -216,7 +216,7 @@ export function makeLanguageCollection(
     let languageDisplayName = getDisplayNamesFromLanguageCode(
         langCode!,
         languages
-    )?.displayNameWithAutonym;
+    )?.combined;
     if (!languageDisplayName) languageDisplayName = langCode;
 
     // We need the label in [Template Language Collection] to be $1.

--- a/src/model/Language.ts
+++ b/src/model/Language.ts
@@ -12,9 +12,9 @@ export function getDisplayNamesFromLanguageCode(
     languages: ILanguage[]
 ):
     | {
-          displayName: string;
-          autonym: string | undefined;
-          displayNameWithAutonym: string;
+          primary: string;
+          secondary: string | undefined;
+          combined: string;
       }
     | undefined {
     const language = languages.find((l) => l.isoCode === languageCode);
@@ -25,22 +25,51 @@ export function getDisplayNamesFromLanguageCode(
 export function getDisplayNamesForLanguage(
     language: ILanguage
 ): {
-    displayName: string;
-    autonym: string | undefined;
-    displayNameWithAutonym: string;
+    primary: string;
+    secondary: string | undefined;
+    combined: string;
 } {
-    let displayName: string;
-    let autonym: string | undefined;
-    let displayNameWithAutonym: string;
-    if (language.englishName && language.englishName !== language.name) {
-        autonym = language.name;
-        displayName = language.englishName;
-        displayNameWithAutonym = `${autonym} (${displayName})`;
-    } else {
-        displayName = language.name;
-        displayNameWithAutonym = displayName;
+    // don't bother showing "zh-CN"... it's not a variant, it's the norm
+    if (language.isoCode === "zh-CN") {
+        return navigator.language === "zh-CN"
+            ? {
+                  secondary: "Chinese",
+                  primary: "简体中文",
+                  combined: "简体中文 (Chinese)",
+              }
+            : {
+                  primary: "Chinese",
+                  secondary: "简体中文",
+                  combined: "Chinese (简体中文)",
+              };
     }
-    return { displayName, autonym, displayNameWithAutonym };
+    let primary: string;
+    let secondary: string | undefined;
+
+    if (language.englishName && language.englishName !== language.name) {
+        if (navigator.language === language.isoCode) {
+            primary = language.name;
+            secondary = language.englishName;
+        } else {
+            primary = language.englishName;
+            secondary = language.name;
+        }
+    } else {
+        primary = language.name;
+    }
+    // if it looks like this is a variant, add that to the secondary
+
+    if (
+        language.isoCode &&
+        language.isoCode.indexOf("-") > -1 &&
+        language.isoCode !== language.englishName &&
+        language.isoCode !== language.name
+    )
+        secondary = [secondary, language.isoCode].join(" ");
+
+    const combined = primary + (secondary ? `(${secondary})` : "");
+
+    return { primary, secondary, combined };
 }
 
 export function getCleanedAndOrderedLanguageList(


### PR DESCRIPTION
* Special handling of Chinese Simplified
* if the UI language is the language in question, make the autonym primary instead of English
* add bcp47 codes to the secondary name if the other names aren't already made of that code (we have a few examples of this)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/212)
<!-- Reviewable:end -->
