### PR TITLE
BL-9374 Fix book card layout

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -61,6 +61,7 @@ export const BookCard: React.FunctionComponent<IProps> = (props) => {
             className={props.className}
             css={css`
                 width: ${BookCardWidth}px;
+                line-height: normal; // counteract css reset
             `}
             key={props.basicBookInfo.baseUrl}
             target={`book/${props.basicBookInfo.objectId}${langParam}`}

--- a/src/components/LanguageFeatureList.tsx
+++ b/src/components/LanguageFeatureList.tsx
@@ -79,7 +79,6 @@ export const LanguageFeatureList: React.FunctionComponent<IProps> = (props) => {
                 margin-top: auto;
                 padding: 3px;
                 overflow: hidden;
-                max-height: calc(2em + 4px);
             `}
         >
             <TruncateMarkup


### PR DESCRIPTION
* caused by CSS reset, apparently
* slight increase to CheapCard height
* change to language feature list max-height calculation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/252)
<!-- Reviewable:end -->
