### PR TITLE
BL-9317 Adjust to phone screens (wip)

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -17,8 +17,7 @@ import { getBestBookTitle } from "../model/Book";
 
 import TruncateMarkup from "react-truncate-markup";
 import { useIntl } from "react-intl";
-
-export const BookCardWidth = 140;
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 interface IProps {
     basicBookInfo: IBasicBookInfo;
@@ -40,6 +39,7 @@ export const BookCard: React.FunctionComponent<IProps> = (props) => {
     const { thumbnailUrl, isModernThumbnail } = getThumbnailUrl(
         props.basicBookInfo
     );
+    const getResponsiveChoice = useResponsiveChoice();
     const title = getBestBookTitle(
         props.basicBookInfo.title,
         props.basicBookInfo.allTitles,
@@ -60,7 +60,8 @@ export const BookCard: React.FunctionComponent<IProps> = (props) => {
         <CheapCard
             className={props.className}
             css={css`
-                width: ${BookCardWidth}px;
+                height: ${getResponsiveChoice(160, 190)}px;
+                width: ${getResponsiveChoice(100, 140)}px;
                 line-height: normal; // counteract css reset
             `}
             key={props.basicBookInfo.baseUrl}
@@ -76,7 +77,7 @@ export const BookCard: React.FunctionComponent<IProps> = (props) => {
             <img
                 className={"swiper-lazy"}
                 css={css`
-                    height: 100px;
+                    height: ${getResponsiveChoice(60, 100)}px;
                     /*cover will crop, but fill up nicely*/
                     object-fit: cover;
                     /* new thumbnails are just the image, and they look better if we see the top and lose some of the bottom
@@ -133,7 +134,9 @@ export const BookCard: React.FunctionComponent<IProps> = (props) => {
                     font-weight: normal;
                     padding-left: ${titlePadding}px;
                     padding-right: ${titlePadding}px;
-                    max-height: 40px;
+                    // need a bit more height on small screen because of thinner
+                    // cards
+                    max-height: ${getResponsiveChoice(50, 40)}px;
                     overflow-y: hidden;
                     margin-top: 3px;
                     margin-bottom: 0;

--- a/src/components/BookCardGroup.tsx
+++ b/src/components/BookCardGroup.tsx
@@ -10,11 +10,12 @@ import LazyLoad, {
 } from "react-lazyload";
 
 import { commonUI } from "../theme";
+import { useResponsiveChoice, useSmallScreen } from "../responsiveUtilities";
 import {
     useSearchBooks,
     IBasicBookInfo,
 } from "../connection/LibraryQueryHooks";
-import { BookCard, BookCardWidth } from "./BookCard";
+import { BookCard } from "./BookCard";
 import { MoreCard } from "./MoreCard";
 import { CardSwiperLazy } from "./CardSwiper";
 import { ICollection } from "../model/ContentInterfaces";
@@ -70,18 +71,16 @@ export const BookCardGroup: React.FunctionComponent<IProps> = (props) => {
                 ></li>
             }
         >
-            <CollectionGroupInner {...props} />
+            <BookCardGroupInner {...props} />
         </LazyLoad>
     );
 };
-export const CollectionGroupInner: React.FunctionComponent<IProps> = (
-    props
-) => {
+const BookCardGroupInner: React.FunctionComponent<IProps> = (props) => {
     // we have either a horizontally-scrolling list of 20, or several rows
     // of 5 each
     const maxCardsToRetrieve = props.rows ? props.rows * 5 : 20;
     const collectionFilter = props.collection.filter ?? {};
-
+    const getResponsiveChoice = useResponsiveChoice();
     const search = useSearchBooks(
         {
             include: "langPointers",
@@ -143,7 +142,6 @@ export const CollectionGroupInner: React.FunctionComponent<IProps> = (
         }
         bookList = (
             <CardSwiperLazy
-                placeHolderWidth={`${BookCardWidth}px`}
                 data={data}
                 getReactElement={(item: IBasicBookInfo | "more", index) => {
                     if (item === "more") {
@@ -226,13 +224,17 @@ export const CollectionGroupInner: React.FunctionComponent<IProps> = (
 
     let group;
     switch (props.collection.layout) {
+        // this is used in the "Create" screen
         case "layout: description-followed-by-row-of-books":
             group = (
                 <React.Fragment>
                     <div
                         css={css`
                             display: flex;
-                            flex-direction: row;
+                            flex-direction: ${getResponsiveChoice(
+                                "column",
+                                "row"
+                            )};
                             // The default margin-left is "auto"
                             .swiper-container {
                                 margin-left: 0;
@@ -245,7 +247,8 @@ export const CollectionGroupInner: React.FunctionComponent<IProps> = (
                                 width: 200px;
                                 min-width: 200px;
                                 max-width: 200px;
-                                margin-right: 20px;
+                                margin-right: ${getResponsiveChoice(10, 20)}px;
+                                margin-bottom: 10px; // for mobile where this is on top
                             `}
                         >
                             <h1>{label}</h1>
@@ -266,7 +269,11 @@ export const CollectionGroupInner: React.FunctionComponent<IProps> = (
         default:
             group = (
                 <React.Fragment>
-                    <h1>
+                    <h1
+                        css={css`
+                            font-size: ${getResponsiveChoice(10, 14)}pt;
+                        `}
+                    >
                         {label}
                         {props.collection.urlKey === "new-arrivals" || (
                             <span

--- a/src/components/BookGroup.tsx
+++ b/src/components/BookGroup.tsx
@@ -16,7 +16,7 @@ import {
     IBasicBookInfo,
 } from "../connection/LibraryQueryHooks";
 import { BookCard } from "./BookCard";
-import { CardSwiper } from "./CardSwiper";
+import { SingleRowCardSwiper } from "./SingleRowCardSwiper";
 
 interface IProps {
     title: string;
@@ -145,8 +145,10 @@ export const BookGroupInner: React.FunctionComponent<IProps> = (props) => {
     //     );
     // }
 
+    // JH Jan 2020: I cannot find anywhere that this is showInOne Row is used.
+    // It's also puzzling that it has to have its own CardSwiper implementation.
     const bookList = showInOneRow ? (
-        <CardSwiper wrapperRole="list">{cards}</CardSwiper>
+        <SingleRowCardSwiper wrapperRole="list">{cards}</SingleRowCardSwiper>
     ) : (
         <div
             css={css`

--- a/src/components/CardGroup.tsx
+++ b/src/components/CardGroup.tsx
@@ -11,17 +11,18 @@ import {
     CollectionLabel,
     useGetLocalizedCollectionLabel,
 } from "../localization/CollectionLabel";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 interface IProps {
     collection: ICollection;
     layout: string;
     data: any[];
-    contentMaker: (x: any, index: number) => ReactElement;
-    placeHolderWidth: string;
+    getCards: (x: any, index: number) => ReactElement;
 }
 
 export const CardGroup: React.FunctionComponent<IProps> = (props) => {
-    const rowHeight = 258; // todo derive from commonui.something
+    const getResponsiveChoice = useResponsiveChoice();
+    const rowHeight = getResponsiveChoice(130, 258) as number; // review: tricky to test because it's for lazy loading
     const cards = (
         <div
             // We want this to be a UL. But accessibility checker insists UL may have
@@ -33,8 +34,7 @@ export const CardGroup: React.FunctionComponent<IProps> = (props) => {
             <CardSwiperLazy
                 wrapperRole="list"
                 data={props.data}
-                getReactElement={props.contentMaker}
-                placeHolderWidth={props.placeHolderWidth}
+                getReactElement={props.getCards}
             />
         </div>
     );
@@ -46,7 +46,11 @@ export const CardGroup: React.FunctionComponent<IProps> = (props) => {
         default:
             group = (
                 <React.Fragment>
-                    <h1>
+                    <h1
+                        css={css`
+                            font-size: ${getResponsiveChoice(10, 14)}pt;
+                        `}
+                    >
                         <CollectionLabel
                             collection={props.collection}
                         ></CollectionLabel>
@@ -85,7 +89,7 @@ export const CardGroup: React.FunctionComponent<IProps> = (props) => {
         >
             <li
                 css={css`
-                    margin-top: 30px;
+                    margin-top: ${getResponsiveChoice(15, 30)}px;
                 `}
                 role="region"
                 aria-label={collectionLabel}

--- a/src/components/CardSwiper.tsx
+++ b/src/components/CardSwiper.tsx
@@ -76,8 +76,7 @@ export const CardSwiperLazy: React.FunctionComponent<{
     // We don't want to render (too many) cards that are not scrolled into view,
     // horizontally. So we make placeholders with this width.
     // If too large, we'll get blank areas. If too small, we just compute
-    // more than we need to.
-    // If too small, when you scroll swiper, it is "jumpy".
+    // more than we need to and when you scroll swiper, it is "jumpy".
     // Alternatively, we could (and once did) plumb things so that we know the
     // exact width of the cards in this row. We stopped doing that because it
     // became complicated when we started changing card sizes depending on the

--- a/src/components/CardSwiper.tsx
+++ b/src/components/CardSwiper.tsx
@@ -4,18 +4,21 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/swiper.min.css";
 import "swiper/components/navigation/navigation.min.css";
 import "swiper/components/a11y/a11y.min.css";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 SwiperCore.use([Navigation, A11y]);
 
-const swiperConfig: Swiper = {
+export const swiperConfig: Swiper = {
     preloadImages: false,
-    lazy: true,
+    lazy: {
+        loadPrevNext: true,
+        loadPrevNextAmount: 3,
+    },
     watchSlidesVisibility: true,
     navigation: {
         nextEl: ".swiper-button-next",
         prevEl: ".swiper-button-prev",
     },
-    spaceBetween: 20,
     slidesPerView: "auto",
     // I'm not clear why this is needed now and wasn't in earlier versions.
     // It allows scrolling a bit further with the right arrow than is possible by default,
@@ -33,48 +36,6 @@ const swiperConfig: Swiper = {
     //a11y: true, // supposed to provide default accessibility behavior, but seems to do nothing.
 };
 
-// Almost obsolete original swiper
-export const CardSwiper: React.FunctionComponent<{
-    children: ReactElement[];
-    // Typically the swiper is a list. I can't find a way to configure it so that the element containing
-    // the cards is a UL, but by setting this to 'list' and making items with role listitem we achieve
-    // the same accessibility goals. This role becomes the value of the role attribute of the swiper
-    // wrapper element, which is the immediate parent of the items. Note that it's not always a list, e.g.,
-    // in the LanguageGroup a further-out element is a listbox and the items have role 'option'.
-    // If you set a wrapperRole, make sure the children you pass have role listitem.
-    wrapperRole?: string;
-}> = (props) => {
-    const [swiper, setSwiper] = useState<any | null>(null);
-    useEffect(() => {
-        if (swiper && props.children.length) {
-            // When the number of children change, if we already had cards and the user has scrolled,
-            // we want to reset the scroll back to the left.
-            // This prevents a UI issue when user has scrolled to the right and then filters the cards.
-            // The cards would otherwise be off the left side of the screen.
-
-            // This check is just for optimization.
-            if (swiper.activeIndex !== 0) {
-                swiper.slideTo(0);
-            }
-            if (props.wrapperRole) {
-                swiper.wrapperEl.setAttribute("role", props.wrapperRole);
-            }
-        }
-    }, [props.children.length, props.wrapperRole, swiper]);
-
-    return (
-        <Swiper {...swiperConfig} onSwiper={setSwiper}>
-            {React.Children.map(props.children, (x, index) => (
-                <SwiperSlide key={index} style={{ width: "initial" }}>
-                    {x}
-                </SwiperSlide>
-            ))}
-            <div className="swiper-button-next swiper-button"></div>
-            <div className="swiper-button-prev swiper-button"></div>
-        </Swiper>
-    );
-};
-
 // This version is much more performant for long lists of cards, many of which are not visible, especially in
 // small windows.
 // Enhance: this could be made generic, with a type param indicating that the type of objects in data
@@ -83,8 +44,8 @@ export const CardSwiperLazy: React.FunctionComponent<{
     data: any[];
     // Given one of the items in data (and its index), return the react element that should be
     // shown for that card when it is visible.
-    getReactElement: (item: any, index: number) => ReactElement;
-    placeHolderWidth: string;
+    getReactElement: (card: any, index: number) => ReactElement;
+
     // Typically the swiper is a list. I can't find a way to configure it so that the element containing
     // the cards is a UL, but by setting this to 'list' and making items with role listitem we achieve
     // the same accessibility goals. This role becomes the value of the role attribute of the swiper
@@ -94,6 +55,7 @@ export const CardSwiperLazy: React.FunctionComponent<{
     wrapperRole?: string;
 }> = (props) => {
     const [swiper, setSwiper] = useState<any | null>(null);
+    const getResponsiveChoice = useResponsiveChoice();
     useEffect(() => {
         if (swiper && props.data.length) {
             // When the number of children change, if we already had cards and the user has scrolled,
@@ -111,6 +73,22 @@ export const CardSwiperLazy: React.FunctionComponent<{
         }
     }, [props.data.length, props.wrapperRole, swiper]);
 
+    // We don't want to render (too many) cards that are not scrolled into view,
+    // horizontally. So we make placeholders with this width.
+    // If too large, we'll get blank areas. If too small, we just compute
+    // more than we need to.
+    // If too small, when you scroll swiper, it is "jumpy".
+    // Alternatively, we could (and once did) plumb things so that we know the
+    // exact width of the cards in this row. We stopped doing that because it
+    // became complicated when we started changing card sizes depending on the
+    // screen size, but it wouldn't be impossible to go back to that.
+    const widthOfPlaceholder = 150;
+
+    // this should be at least 1, which makes things smooth for clicking on
+    // "next". Beyond that, it is for making things smooth while dragging.
+    const kNumberOfCardsToRenderWhileInvisible = 3;
+    let indexOfLastVisibleCard = 0;
+
     return (
         // I believe it ought to be possible to use the 'virtual' feature of Swiper so that only the visible
         // cards get created at all, but I had trouble getting it to work, particularly in LanguageGroup.
@@ -124,16 +102,39 @@ export const CardSwiperLazy: React.FunctionComponent<{
         // The Swiper stylesheet sets SwiperSlides to be 100% width for some reason; we want them
         // to be the size of the generated child element, so I gave them a style that forces "initial"
         // to make the cards use the size of their content.
-        <Swiper {...swiperConfig} onSwiper={setSwiper}>
-            {props.data.map((item: any, index: number) => (
-                <SwiperSlide style={{ width: "initial" }} key={index}>
-                    {(args: any) =>
-                        args.isVisible ? (
-                            props.getReactElement(item, index)
-                        ) : (
-                            <div style={{ width: props.placeHolderWidth }} />
+
+        <Swiper
+            {...swiperConfig}
+            spaceBetween={getResponsiveChoice(10, 20) as number}
+            onSwiper={setSwiper}
+        >
+            {props.data.map((card: any, index: number) => (
+                <SwiperSlide
+                    style={{
+                        width: "initial",
+                    }}
+                    key={index}
+                >
+                    {(args: any) => {
+                        if (
+                            args.isVisible ||
+                            // Render a couple cards to be ready
+                            // Note that will render cards that have already been
+                            // scrolled off to the left.
+                            indexOfLastVisibleCard >
+                                index - kNumberOfCardsToRenderWhileInvisible
                         )
-                    }
+                            indexOfLastVisibleCard = index;
+                        return args.isVisible ? (
+                            props.getReactElement(card, index)
+                        ) : (
+                            <div
+                                style={{
+                                    width: `${widthOfPlaceholder}px`,
+                                }}
+                            />
+                        );
+                    }}
                 </SwiperSlide>
             ))}
             <div className="swiper-button-next swiper-button"></div>

--- a/src/components/CheapCard.tsx
+++ b/src/components/CheapCard.tsx
@@ -18,7 +18,6 @@ interface IProps extends React.HTMLProps<HTMLDivElement> {
 // just a wrapper around the children you provide, made to look like a card and responsive to a click.
 export const CheapCard: React.FunctionComponent<IProps> = (props) => {
     const url = getUrlForTarget(props.target || "");
-    const getResponsiveChoice = useResponsiveChoice();
     return (
         <BlorgLink
             className={`cheapCard ${props.className}`}

--- a/src/components/CheapCard.tsx
+++ b/src/components/CheapCard.tsx
@@ -7,17 +7,18 @@ import React from "react";
 import { commonUI } from "../theme";
 import { getUrlForTarget } from "./Routes";
 import { BlorgLink } from "./BlorgLink";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 interface IProps extends React.HTMLProps<HTMLDivElement> {
     className?: string;
     target?: string; // what we're calling "target" is the last part of url, where the url is <breadcrumb stuff>/<target>
     role?: string;
-    kind?: "short" | undefined;
 }
 
 // just a wrapper around the children you provide, made to look like a card and responsive to a click.
 export const CheapCard: React.FunctionComponent<IProps> = (props) => {
     const url = getUrlForTarget(props.target || "");
+    const getResponsiveChoice = useResponsiveChoice();
     return (
         <BlorgLink
             className={`cheapCard ${props.className}`}
@@ -28,9 +29,6 @@ export const CheapCard: React.FunctionComponent<IProps> = (props) => {
                 flex-direction: column;
 
                 margin-bottom: ${commonUI.cheapCardMarginBottomInPx}px;
-                height: ${props.kind === "short"
-                    ? "40px"
-                    : "190px"}; // todo derive from commonUI.something
                 margin-right: 5px;
                 background-color: white;
                 border-radius: 4px;
@@ -59,6 +57,10 @@ export const CheapCard: React.FunctionComponent<IProps> = (props) => {
                 &:visited {
                     color: black;
                 }
+
+                // NOTE! There are more css rules that can come from the parent
+                // component, e.g. collection card. In the debugger they'll all
+                // show together (with the overrides from the parent at the end).
             `}
             href={url}
             role={props.role}

--- a/src/components/FeatureMatrix.tsx
+++ b/src/components/FeatureMatrix.tsx
@@ -28,6 +28,7 @@ const defaultColor = "black";
 const columOneWidth = "auto";
 
 export const FeatureMatrix: React.FunctionComponent<{}> = (props) => {
+    const getResponsiveChoice = useResponsiveChoice();
     return (
         <TableContainer
             component={Paper}
@@ -35,7 +36,7 @@ export const FeatureMatrix: React.FunctionComponent<{}> = (props) => {
                 background-color: ${backgroundColor}!important;
                 margin-left: auto;
                 margin-right: auto;
-                width: fit-content !important;
+                width: ${getResponsiveChoice("", "fit-content")} !important;
             `}
         >
             <Table
@@ -49,6 +50,12 @@ export const FeatureMatrix: React.FunctionComponent<{}> = (props) => {
                     th,
                     td {
                         border: none !important;
+                        padding-left: 0;
+                    }
+                    .levelName,
+                    .feature {
+                        font-size: ${getResponsiveChoice(10, 14)}px;
+                        line-height: 1em;
                     }
                 `}
             >
@@ -64,9 +71,15 @@ export const FeatureMatrix: React.FunctionComponent<{}> = (props) => {
                         `}
                     >
                         <TableCell></TableCell>
-                        <TableCell align="center">Free</TableCell>
-                        <TableCell align="center">Local Community</TableCell>
-                        <TableCell align="center">Enterprise</TableCell>
+                        <TableCell className="levelName" align="center">
+                            Free
+                        </TableCell>
+                        <TableCell className="levelName" align="center">
+                            Local Community
+                        </TableCell>
+                        <TableCell className="levelName" align="center">
+                            Enterprise
+                        </TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>{props.children}</TableBody>
@@ -123,19 +136,27 @@ export const Feature: React.FunctionComponent<{
                         color: ${defaultColor};
                     }
                     background-color: ${blockColor};
+
+                    .checkMarkHolder {
+                        svg {
+                            height: ${getResponsiveChoice(16, 24)}px;
+                        }
+                    }
                 `}
             >
+                {/* 1st column, feature label */}
                 <TableCell
                     component="th"
                     scope="row"
                     css={css`
                         /* width: ${columOneWidth}; */
                         font-weight: 600 !important;
-                        font-size: ${getResponsiveChoice(9, 16)}px !important;
+                        font-size: ${getResponsiveChoice(10, 16)}px !important;
                         &,
                         * {
                             color: ${defaultColor};
                         }
+                        display: flex;
                     `}
                 >
                     <span
@@ -144,7 +165,7 @@ export const Feature: React.FunctionComponent<{
                             display: inline-block;
                         `}
                     >
-                        {hasChildren && (
+                        {hasChildren ? (
                             <IconButton
                                 aria-label="expand row"
                                 size="small"
@@ -159,15 +180,33 @@ export const Feature: React.FunctionComponent<{
                                     <KeyboardArrowDownIcon />
                                 )}
                             </IconButton>
+                        ) : (
+                            // just take up that space so that if the feature
+                            // label is really long and wrap, it won't take up
+                            // this space and fall out of alignment
+                            <div
+                                css={css`
+                                    padding: 0;
+                                    margin: 0;
+                                `}
+                            ></div>
                         )}
                     </span>
-                    {props.name}
+                    <div
+                        css={css`
+                            padding-top: 8px;
+                        `}
+                    >
+                        {props.name}
+                    </div>
                 </TableCell>
-                <TableCell align="center">{all && <Check />}</TableCell>
-                <TableCell align="center">
+                <TableCell className="checkMarkHolder" align="center">
+                    {all && <Check />}
+                </TableCell>
+                <TableCell className="checkMarkHolder" align="center">
                     {(all || props.community) && <Check />}
                 </TableCell>
-                <TableCell align="center">
+                <TableCell className="checkMarkHolder" align="center">
                     {(all || props.community || props.enterprise) && <Check />}
                 </TableCell>
             </TableRow>
@@ -182,10 +221,11 @@ export const Feature: React.FunctionComponent<{
                         padding-bottom: 0;
                         padding-top: 0;
                         width: 300px;
-                        font-size: ${getResponsiveChoice(9, 16)}px !important;
+                        font-size: ${getResponsiveChoice(10, 16)}px !important;
+                        padding-left: 10px !important; // see "Record by sentence"
                     `}
                 >
-                    {/* This is the mardown content that describes the feature */}
+                    {/* This is the markdown content that describes the feature */}
                     {hasChildren && (
                         <Collapse in={open} timeout="auto" unmountOnExit>
                             {props.children}

--- a/src/components/FeatureMatrix.tsx
+++ b/src/components/FeatureMatrix.tsx
@@ -18,6 +18,7 @@ import Check from "@material-ui/icons/Check";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import Collapse from "@material-ui/core/Collapse";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 const backgroundColor = "white";
 const headerColor = commonUI.colors.createAreaTextOnWhite;
@@ -108,6 +109,7 @@ export const Feature: React.FunctionComponent<{
     enterprise: boolean;
 }> = (props) => {
     const [open, setOpen] = React.useState(false);
+    const getResponsiveChoice = useResponsiveChoice();
     const all = !(props.community || props.enterprise);
     const hasChildren = React.Children.count(props.children) > 0;
     return (
@@ -127,9 +129,9 @@ export const Feature: React.FunctionComponent<{
                     component="th"
                     scope="row"
                     css={css`
-                        width: ${columOneWidth};
+                        /* width: ${columOneWidth}; */
                         font-weight: 600 !important;
-                        font-size: 1rem !important;
+                        font-size: ${getResponsiveChoice(9, 16)}px !important;
                         &,
                         * {
                             color: ${defaultColor};
@@ -180,6 +182,7 @@ export const Feature: React.FunctionComponent<{
                         padding-bottom: 0;
                         padding-top: 0;
                         width: 300px;
+                        font-size: ${getResponsiveChoice(9, 16)}px !important;
                     `}
                 >
                     {/* This is the mardown content that describes the feature */}

--- a/src/components/LanguageCard.tsx
+++ b/src/components/LanguageCard.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { CheapCard } from "./CheapCard";
 import { ILanguage, getDisplayNamesForLanguage } from "../model/Language";
 import { commonUI } from "../theme";
+import { useResponsiveChoice } from "../responsiveUtilities";
 import { useTheme } from "@material-ui/core";
 import { FormattedMessage } from "react-intl";
 import TruncateMarkup from "react-truncate-markup";
@@ -15,8 +16,6 @@ import TruncateMarkup from "react-truncate-markup";
 interface ILanguageWithRole extends ILanguage {
     role?: string; // accessibility role, passed on as part of propsToPassDown
 }
-
-export const languageCardWidth = "140px";
 
 export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
     props
@@ -32,14 +31,16 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
     } = props; // Prevent React warnings
     const cardPadding = "14px";
     const { primary, secondary } = getDisplayNamesForLanguage(props);
-
+    const getResponsiveChoice = useResponsiveChoice();
     return (
         <CheapCard
             {...propsToPassDown} // makes swiper work
             css={css`
-                //text-align: center;
-                width: ${languageCardWidth};
-                height: ${commonUI.languageCardHeightInPx}px;
+                // Width was chosen for "portuguese" to fit on one line in mobile
+                // and desktop
+                width: ${getResponsiveChoice(100, 150)}px;
+                // When choosing a height, search on "x-" to see some tall ones
+                height: ${getResponsiveChoice(90, 125)}px;
                 padding: ${cardPadding};
             `}
             target={`/language:${props.isoCode}`}
@@ -47,10 +48,14 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
         >
             <div
                 css={css`
-                    font-size: 0.9rem;
+                    font-size: ${getResponsiveChoice(9, 12)}pt;
                     // allows the child, the actual secondary name, to be absolute positioned to the bottom
                     position: relative;
-                    height: 35px; // push the next name, the primary name, into the center of the card
+                    height: ${getResponsiveChoice(
+                        25,
+                        35
+                    )}px; // push the next name, the primary name, into the center of the card
+                    margin-bottom: 5px;
                 `}
             >
                 <div
@@ -59,32 +64,37 @@ export const LanguageCard: React.FunctionComponent<ILanguageWithRole> = (
                         position: absolute;
                         bottom: 0;
                         color: ${commonUI.colors.minContrastGray};
+                        line-height: 1em;
                     `}
                 >
+                    {/* in small mode didn't work, allowed 3 lines <TruncateMarkup lines={2}>
+                    I think the rare 3 line cases (search for "x-") look ok.
+
+                        <span>{secondary}</span>
+                    </TruncateMarkup> */}
                     {secondary}
                 </div>
             </div>
             <h2
                 css={css`
+                    font-size: ${getResponsiveChoice(9, 16)}pt;
                     //text-align: center;
                     max-height: 40px;
                     margin-top: 0;
                     margin-bottom: 0;
                     margin-block-start: 0;
                     margin-block-end: 0;
+                    line-height: 1em;
                 `}
             >
-                <TruncateMarkup
-                    // test false positives css={css`color: red;`}
-                    lines={2}
-                >
+                <TruncateMarkup lines={2}>
                     <span> {primary} </span>
                 </TruncateMarkup>
             </h2>
             <div
                 css={css`
-                    font-size: 0.7rem;
-                    color: ${theme.palette.secondary.main};
+                    font-size: ${getResponsiveChoice(10, 14)}px;
+
                     position: absolute;
                     bottom: ${cardPadding};
                 `}

--- a/src/components/LanguageGroup.tsx
+++ b/src/components/LanguageGroup.tsx
@@ -5,7 +5,7 @@ import { jsx } from "@emotion/core";
 /** @jsx jsx */
 
 import React, { useContext, useState } from "react";
-import { LanguageCard, languageCardWidth } from "./LanguageCard";
+import { LanguageCard } from "./LanguageCard";
 import Downshift, {
     GetItemPropsOptions,
     GetMenuPropsOptions,
@@ -20,6 +20,7 @@ import { CardSwiperLazy } from "./CardSwiper";
 import { Redirect } from "react-router-dom";
 import { FormattedMessage, useIntl } from "react-intl";
 import { propsToHideAccessibilityElement } from "../Utilities";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 export const LanguageGroup: React.FunctionComponent = () => {
     const l10n = useIntl();
@@ -27,7 +28,7 @@ export const LanguageGroup: React.FunctionComponent = () => {
     // setting this to a language code causes a <Redirect> to render and open the page
     // for that code (currently when the user has selected a language by typing and pressing Enter)
     const [langChosen, setLangChosen] = useState("");
-
+    const getResponsiveChoice = useResponsiveChoice();
     let filteredLanguages: ILanguage[] = [];
 
     const getFilteredLanguages = (filter: string | null): ILanguage[] => {
@@ -47,9 +48,8 @@ export const LanguageGroup: React.FunctionComponent = () => {
                 <div {...getMenuProps({})}>
                     <CardSwiperLazy
                         data={filteredLanguages}
-                        placeHolderWidth={languageCardWidth}
                         getReactElement={(l: ILanguage, index: number) => (
-                            // JohnnT: I think this comment is wrong; getLabelProps is actually to do with a label for
+                            // JohnT: I think this comment is wrong; getLabelProps is actually to do with a label for
                             // the whole chooser.
                             // TODO: to complete the accessibility, we need to pass the Downshift getLabelProps into LanguageCard
                             // and apply it to the actual label.
@@ -71,9 +71,6 @@ export const LanguageGroup: React.FunctionComponent = () => {
             return (
                 <div
                     css={css`
-                        height: ${commonUI.languageCardHeightInPx +
-                        commonUI.cheapCardMarginBottomInPx -
-                        10}px; // 10 matches the padding-top
                         padding-top: 10px;
                         font-size: 0.8rem;
                     `}
@@ -105,13 +102,7 @@ export const LanguageGroup: React.FunctionComponent = () => {
     return langChosen ? (
         <Redirect to={"/language:" + langChosen} />
     ) : (
-        <li
-            css={css`
-                margin-top: 30px;
-            `}
-            role="region"
-            aria-labelledby="findBooksByLanguage"
-        >
+        <li role="region" aria-labelledby="findBooksByLanguage">
             <h1
                 // This has an ID to match the aria-labelledby above.
                 // The FormattedMessage has an ID to look up the message, but its ID does not
@@ -145,7 +136,11 @@ export const LanguageGroup: React.FunctionComponent = () => {
                         getMenuProps,
                         inputValue: currentInputBoxText,
                     }) => (
-                        <div>
+                        <div
+                            css={css`
+                                height: ${getResponsiveChoice(140, 160)}px;
+                            `}
+                        >
                             <div
                                 css={css`
                                     display: flex;
@@ -227,11 +222,7 @@ export const LanguageGroup: React.FunctionComponent = () => {
                 </Downshift>
             )) || (
                 // still loading or no response
-                <div
-                    css={css`
-                        height: 100px;
-                    `}
-                >
+                <div>
                     <FormattedMessage
                         id="loading"
                         defaultMessage="Loading..."

--- a/src/components/RowOfCards.tsx
+++ b/src/components/RowOfCards.tsx
@@ -50,7 +50,7 @@ const RowOfCardsInternal: React.FunctionComponent<{
     //     x.label.localeCompare(y.label)
     // );
     const childCollections = props.collection.childCollections;
-    console.log(`${props.collection.label} ${props.collection.layout}`);
+
     return (
         <CardGroup
             collection={props.collection}

--- a/src/components/RowOfCards.tsx
+++ b/src/components/RowOfCards.tsx
@@ -1,11 +1,17 @@
+// this engages a babel macro that does cool emotion stuff (like source maps). See https://emotion.sh/docs/babel-macros
+import css from "@emotion/css/macro";
+// these two lines make the css prop work on react elements
+import { jsx } from "@emotion/core";
+/** @jsx jsx */
+
 import React from "react";
 import { useGetCollection } from "../model/Collections";
 import { CardGroup } from "./CardGroup";
-import { CollectionCard, collectionCardWidth } from "./CollectionCard";
+import { CollectionCard } from "./CollectionCard";
 import { BookCardGroup } from "./BookCardGroup";
 import { PageNotFound } from "./PageNotFound";
 import { ICollection } from "../model/ContentInterfaces";
-import { StoryCard, storyCardWidth } from "./StoryCard";
+import { StoryCard } from "./StoryCard";
 
 // These can be a group of book cards, collection cards, story page cards, or generic page cards
 export const RowOfCards: React.FunctionComponent<{
@@ -44,17 +50,12 @@ const RowOfCardsInternal: React.FunctionComponent<{
     //     x.label.localeCompare(y.label)
     // );
     const childCollections = props.collection.childCollections;
-
+    console.log(`${props.collection.label} ${props.collection.layout}`);
     return (
         <CardGroup
             collection={props.collection}
             data={childCollections}
-            placeHolderWidth={
-                props.collection.layout === "row-of-story-cards"
-                    ? storyCardWidth
-                    : collectionCardWidth
-            }
-            contentMaker={(childCollection: ICollection, index) => {
+            getCards={(childCollection: ICollection, index) => {
                 switch (props.collection.layout) {
                     case "row-of-story-cards":
                         return (
@@ -63,16 +64,27 @@ const RowOfCardsInternal: React.FunctionComponent<{
                                 key={childCollection.urlKey}
                             />
                         );
+                    case "row-of-cards-with-just-labels":
+                        return (
+                            <CollectionCard
+                                collection={childCollection}
+                                key={childCollection.urlKey}
+                                layout={"short"}
+                            />
+                        );
+                    // Row of different topic cards will use this
+                    case "row-of-cards-with-just-labels-and-book-count":
+                        return (
+                            <CollectionCard
+                                collection={childCollection}
+                                key={childCollection.urlKey}
+                                layout={"short-with-book-count"}
+                            />
+                        );
                     default:
                         return (
                             <CollectionCard
                                 collection={childCollection}
-                                kind={
-                                    props.collection.layout ===
-                                    "row-of-cards-with-just-labels"
-                                        ? "short"
-                                        : undefined
-                                }
                                 key={childCollection.urlKey}
                             />
                         );

--- a/src/components/SingleRowCardSwiper.tsx
+++ b/src/components/SingleRowCardSwiper.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement, useEffect, useState } from "react";
+import SwiperCore, { Navigation, A11y } from "swiper";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/swiper.min.css";
+import "swiper/components/navigation/navigation.min.css";
+import "swiper/components/a11y/a11y.min.css";
+import { swiperConfig } from "./CardSwiper";
+
+SwiperCore.use([Navigation, A11y]);
+
+// Almost obsolete original swiper.
+// Jan 2020 I (JH) renaming this because I just wasted 30
+// minutes wondering why nothing I did ever effected ANYTHING, only to discover
+// that the *real* swiper is called CardSwiperLazy. I cannot find
+// anywhere where this is used. When we do find it, for goodness sake just get
+// rid of this figure out how to make the normal CardSwiperLazy (or it's better
+// name, if we have gotten to that point) to work.
+export const SingleRowCardSwiper: React.FunctionComponent<{
+    children: ReactElement[];
+    // Typically the swiper is a list. I can't find a way to configure it so that the element containing
+    // the cards is a UL, but by setting this to 'list' and making items with role listitem we achieve
+    // the same accessibility goals. This role becomes the value of the role attribute of the swiper
+    // wrapper element, which is the immediate parent of the items. Note that it's not always a list, e.g.,
+    // in the LanguageGroup a further-out element is a listbox and the items have role 'option'.
+    // If you set a wrapperRole, make sure the children you pass have role listitem.
+    wrapperRole?: string;
+}> = (props) => {
+    const [swiper, setSwiper] = useState<any | null>(null);
+    useEffect(() => {
+        if (swiper && props.children.length) {
+            // When the number of children change, if we already had cards and the user has scrolled,
+            // we want to reset the scroll back to the left.
+            // This prevents a UI issue when user has scrolled to the right and then filters the cards.
+            // The cards would otherwise be off the left side of the screen.
+
+            // This check is just for optimization.
+            if (swiper.activeIndex !== 0) {
+                swiper.slideTo(0);
+            }
+            if (props.wrapperRole) {
+                swiper.wrapperEl.setAttribute("role", props.wrapperRole);
+            }
+        }
+    }, [props.children.length, props.wrapperRole, swiper]);
+
+    return (
+        <Swiper {...swiperConfig} onSwiper={setSwiper}>
+            {React.Children.map(props.children, (x, index) => (
+                <SwiperSlide
+                    key={index}
+                    style={{
+                        width: "initial",
+                    }}
+                >
+                    {x}
+                </SwiperSlide>
+            ))}
+            <div className="swiper-button-next swiper-button"></div>
+            <div className="swiper-button-prev swiper-button"></div>
+        </Swiper>
+    );
+};

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -14,12 +14,12 @@ import Typography from "@material-ui/core/Typography";
 import { Link } from "react-router-dom";
 import { getUrlForTarget } from "./Routes";
 import { useContentfulPage } from "./pages/ContentfulPage";
-
-export const storyCardWidth = "240px";
+import { useResponsiveChoice } from "../responsiveUtilities";
 
 export const StoryCard: React.FunctionComponent<{ story: ICollection }> = (
     props
 ) => {
+    const getResponsiveChoice = useResponsiveChoice();
     const url = "/page/" + getUrlForTarget(props.story.urlKey);
     const page = useContentfulPage("page", props.story.urlKey);
     if (!page) {
@@ -28,7 +28,7 @@ export const StoryCard: React.FunctionComponent<{ story: ICollection }> = (
     return (
         <Card
             css={css`
-                width: ${storyCardWidth};
+                width: ${getResponsiveChoice(120, 240)}px;
                 // I don't know why, but without this, the edges get cut off
                 margin: 1px;
                 // enhance: really we just want this margin in-between cards
@@ -38,22 +38,41 @@ export const StoryCard: React.FunctionComponent<{ story: ICollection }> = (
             <CardActionArea component={Link} to={`${url}`}>
                 <CardMedia
                     css={css`
-                        width: 240px;
                         height: 160px;
                     `}
                     image={page.cardImage?.url}
                 />
-                <CardContent>
-                    <Typography color="textSecondary" gutterBottom>
+                <CardContent
+                    css={css`
+                        height: ${getResponsiveChoice(190, 190)}px;
+                    `}
+                >
+                    <Typography
+                        color="textSecondary"
+                        gutterBottom
+                        css={css`
+                            font-size: ${getResponsiveChoice(11, 14)}px;
+                        `}
+                    >
                         {page.category}
                     </Typography>
-                    <Typography gutterBottom variant="h5" component="h2">
+                    <Typography
+                        gutterBottom
+                        variant="h5"
+                        component="h2"
+                        css={css`
+                            font-size: ${getResponsiveChoice(12, 16)}px;
+                            font-weight: bold;
+                        `}
+                    >
                         {page.label}
                     </Typography>
                     <Typography
                         variant="body2"
-                        color="textSecondary"
                         component="p"
+                        css={css`
+                            font-size: ${getResponsiveChoice(11, 14)}px;
+                        `}
                     >
                         {page.fields.excerpt}
                     </Typography>

--- a/src/components/banners/Banner.tsx
+++ b/src/components/banners/Banner.tsx
@@ -7,6 +7,7 @@ import { jsx } from "@emotion/core";
 import { ICollection, IBanner } from "../../model/ContentInterfaces";
 import { StandardBannerLayout } from "./StandardBannerLayout";
 import { ImageOnRightBannerLayout } from "./ImageOnRightBannerLayout";
+import { useClassForSmallScreen } from "../../responsiveUtilities";
 export const Banner: React.FunctionComponent<{
     collection: ICollection;
     banner: IBanner;
@@ -15,6 +16,7 @@ export const Banner: React.FunctionComponent<{
     const defaultTextColor = props.banner.backgroundImage ? "white" : "black";
     return (
         <div
+            className={useClassForSmallScreen()}
             css={css`
                 display: flex;
                 flex-direction: column;
@@ -23,14 +25,11 @@ export const Banner: React.FunctionComponent<{
                 * {
                     color: ${props.banner.textColor || defaultTextColor};
                 }
-                /* a {
-                    font-size: 14pt;
-                } */
+
                 a:visited {
                     text-decoration: underline;
                 }
                 background-color: ${props.banner.backgroundColor};
-
                 /* this can override any of the above*/
                 ${props.banner.css}
             `}

--- a/src/components/banners/Blurb.tsx
+++ b/src/components/banners/Blurb.tsx
@@ -20,7 +20,6 @@ export const Blurb: React.FunctionComponent<{
     hideTitle: boolean;
 }> = (props) => {
     const l10n = useIntl();
-    const getResponsiveChoice = useResponsiveChoice();
     return (
         <div
             css={css`

--- a/src/components/banners/Blurb.tsx
+++ b/src/components/banners/Blurb.tsx
@@ -10,6 +10,7 @@ import { ButtonRow } from "../ButtonRow";
 import { CollectionLabel } from "../../localization/CollectionLabel";
 import { BlorgMarkdown } from "../BlorgMarkdown";
 import { useIntl } from "react-intl";
+import { useResponsiveChoice } from "../../responsiveUtilities";
 
 export const Blurb: React.FunctionComponent<{
     collection: ICollection;
@@ -19,7 +20,7 @@ export const Blurb: React.FunctionComponent<{
     hideTitle: boolean;
 }> = (props) => {
     const l10n = useIntl();
-
+    const getResponsiveChoice = useResponsiveChoice();
     return (
         <div
             css={css`
@@ -37,7 +38,6 @@ export const Blurb: React.FunctionComponent<{
                 css={css`
                     font-weight: normal;
                     max-width: 600px;
-                    margin-bottom: 10px;
                     overflow: hidden auto; // 'hidden' for x; 'auto' for y
                 `}
             >

--- a/src/connection/GetQueryResultsUI.tsx
+++ b/src/connection/GetQueryResultsUI.tsx
@@ -4,13 +4,10 @@ import { css } from "@emotion/core";
 
 export function getNoResultsElement() {
     return (
-        <div
-            css={css`
-                background-color: lightgray;
-                width: 100px;
-                height: 20px;
-            `}
-        />
+        <div>
+            {/* without this we don't get line and then the screen jumps */}
+            {"-"}
+        </div>
     );
 }
 

--- a/src/model/RouterContent.tsx
+++ b/src/model/RouterContent.tsx
@@ -10,6 +10,7 @@ import { Header } from "../components/header/Header";
 import { Routes } from "../components/Routes";
 import { Footer } from "../components/Footer";
 import { useIsEmbedded } from "../components/EmbeddingHost";
+import { useRefreshWhenScreenSizeChanges } from "../responsiveUtilities";
 
 // What we want inside the <Router> component. Has to be its own component so that we can have
 // useLocation(), which only works inside the Router.
@@ -17,6 +18,7 @@ export const RouterContent: React.FunctionComponent<{}> = (props) => {
     const location = useLocation();
     const showingPlayer = location.pathname.startsWith("/player/");
     const embeddedMode = useIsEmbedded();
+    useRefreshWhenScreenSizeChanges();
     return (
         <React.Fragment>
             {embeddedMode || showingPlayer || <Header />}

--- a/src/responsiveUtilities.ts
+++ b/src/responsiveUtilities.ts
@@ -1,0 +1,63 @@
+//import { debounce } from "throttle-debounce";
+import { useMediaQuery, useTheme } from "@material-ui/core";
+import { useEffect, useState } from "react";
+
+// Do not use this all over, it's expensive
+export function useRefreshWhenScreenSizeChanges() {
+    // Initialize state with undefined width/height so server and client renders match
+    // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+    const [windowSize, setWindowSize] = useState({
+        width: window.innerWidth,
+        height: window.innerHeight,
+    });
+
+    useEffect(() => {
+        // Handler to call on window resize
+        function handleResize() {
+            // Set window width/height to state
+            setWindowSize({
+                width: window.innerWidth,
+                height: window.innerHeight,
+            });
+            //console.log("resize");
+        }
+
+        // Add event listener
+        window.addEventListener(
+            "resize",
+            // this should cause a refresh at most 5 times per second... it didn't seem to help performance, but it did
+            // have a problem of often dropping the resize altogether
+            //debounce(200, false, handleResize)
+            handleResize
+        );
+        // Remove event listener on cleanup
+        return () => window.removeEventListener("resize", handleResize);
+    }, []); // Empty array ensures that effect is only run on mount
+}
+export function useSmallScreen() {
+    const theme = useTheme();
+    // I don't get how this can be so large: return
+    return useMediaQuery(theme.breakpoints.down("xs"));
+    //useMediaQuery(theme.breakpoints.up("(max-width:600px"));
+}
+export function useClassForSmallScreen() {
+    return useSmallScreen() ? "smallScreen" : "";
+}
+
+// export function useShrinkOnSmallScreen() {
+//     const x = useSmallScreen(); // review... it wouldn't let me put this in the callback... w
+//     return (w: number | undefined, scaleFactor?: number) => {
+//         if (w === undefined) return w;
+//         return x ? w * (scaleFactor || 0.5) : w;
+//     };
+// }
+
+export function useResponsiveChoice() {
+    const isSmall = useSmallScreen();
+    return (
+        smallest: number | string,
+        largest: number | string
+    ): number | string => {
+        return isSmall ? smallest : largest;
+    };
+}

--- a/src/responsiveUtilities.ts
+++ b/src/responsiveUtilities.ts
@@ -4,25 +4,19 @@ import { useEffect, useState } from "react";
 
 // Do not use this all over, it's expensive
 export function useRefreshWhenScreenSizeChanges() {
-    // Initialize state with undefined width/height so server and client renders match
-    // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
     const [windowSize, setWindowSize] = useState({
         width: window.innerWidth,
         height: window.innerHeight,
     });
 
     useEffect(() => {
-        // Handler to call on window resize
         function handleResize() {
-            // Set window width/height to state
             setWindowSize({
                 width: window.innerWidth,
                 height: window.innerHeight,
             });
-            //console.log("resize");
         }
 
-        // Add event listener
         window.addEventListener(
             "resize",
             // this should cause a refresh at most 5 times per second... it didn't seem to help performance, but it did
@@ -36,7 +30,7 @@ export function useRefreshWhenScreenSizeChanges() {
 }
 export function useSmallScreen() {
     const theme = useTheme();
-    // I don't get how this can be so large: return
+    // Note that iwth material's breakpoints, you have to get down to "xs" for phone size
     return useMediaQuery(theme.breakpoints.down("xs"));
     //useMediaQuery(theme.breakpoints.up("(max-width:600px"));
 }
@@ -55,9 +49,9 @@ export function useClassForSmallScreen() {
 export function useResponsiveChoice() {
     const isSmall = useSmallScreen();
     return (
-        smallest: number | string,
-        largest: number | string
+        smallScreenValue: number | string,
+        largeScreenValue: number | string
     ): number | string => {
-        return isSmall ? smallest : largest;
+        return isSmall ? smallScreenValue : largeScreenValue;
     };
 }

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -19,7 +19,6 @@ export const commonUI = {
 
     // Some of these aren't very global, but this is a convenient place to put
     // constants shared by various components to keep them consistent
-    languageCardHeightInPx: 120,
     cheapCardMarginBottomInPx: 10,
     bookGroupTopMarginPx: 30,
     bookCardHeightPx: 200,


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-9317
Move cards to the new left-aligned, space-saving design
Banner sizing
Card sizing
Cards spacing
Clarified the names around the 2 versions of cardswiper

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/260)
<!-- Reviewable:end -->
