### PR TITLE
Fully render cards near the visible window (BL-9421)

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -14,8 +14,9 @@ import Typography from "@material-ui/core/Typography";
 import { Link } from "react-router-dom";
 import { getUrlForTarget } from "./Routes";
 import { useContentfulPage } from "./pages/ContentfulPage";
-import { useResponsiveChoice } from "../responsiveUtilities";
+import { useResponsiveChoice, useSmallScreen } from "../responsiveUtilities";
 import { ICardSpec } from "./RowOfCards";
+import TruncateMarkup from "react-truncate-markup";
 
 export function useStoryCardSpec(): ICardSpec {
     const getResponsiveChoice = useResponsiveChoice();
@@ -33,6 +34,7 @@ export const StoryCard: React.FunctionComponent<{ story: ICollection }> = (
 ) => {
     const { cardWidthPx, cardHeightPx } = useStoryCardSpec();
     const getResponsiveChoice = useResponsiveChoice();
+    const isSmall = useSmallScreen();
     const url = "/page/" + getUrlForTarget(props.story.urlKey);
     const page = useContentfulPage("page", props.story.urlKey);
     if (!page) {
@@ -87,7 +89,12 @@ export const StoryCard: React.FunctionComponent<{ story: ICollection }> = (
                             font-size: ${getResponsiveChoice(11, 14)}px;
                         `}
                     >
-                        {page.fields.excerpt}
+                        {/* For some reason 8 produces 9 lines...which seems to be about right for the tall cards we have in small
+                        screen mode. The wider but shorter big-screen cards only have room for six, though that is usually more text.
+                        Big screen cutoff is not tested as I don't know of a story with more than five lines of excerpt. */}
+                        <TruncateMarkup lines={isSmall ? 8 : 6}>
+                            <span>{page.fields.excerpt}</span>
+                        </TruncateMarkup>
                     </Typography>
                 </CardContent>
             </CardActionArea>


### PR DESCRIPTION
In particular we don't want to stop rendering real card content before a card actually scrolls out of view (i.e., during the animation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/276)
<!-- Reviewable:end -->
