### PR TITLE
Implement Get Template button (BL-9584)

### DIFF
--- a/src/assets/Template.svg
+++ b/src/assets/Template.svg
@@ -1,0 +1,5 @@
+<svg width="31" height="38" viewBox="0 0 31 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.45703" y="0.5" width="22.5323" height="29.4548" fill="white" stroke="#1D94A4" stroke-dasharray="2 1"/>
+<rect x="4.56641" y="4.43994" width="22.5323" height="29.4548" fill="white" stroke="#1D94A4" stroke-dasharray="2 1"/>
+<rect x="7.56641" y="7.95459" width="22.5323" height="29.4548" fill="white" stroke="#1D94A4" stroke-dasharray="2 1"/>
+</svg>

--- a/src/components/BookDetail/BookDetailHeaderGroup.tsx
+++ b/src/components/BookDetail/BookDetailHeaderGroup.tsx
@@ -22,6 +22,7 @@ import { useIsEmbedded } from "../EmbeddingHost";
 import { FormattedMessage } from "react-intl";
 import { BookThumbnail } from "./BookThumbnail";
 import { BlorgLink } from "../BlorgLink";
+import { DownloadToBloomButton } from "./DownloadToBloomButton";
 
 export const BookDetailHeaderGroup: React.FunctionComponent<{
     book: Book;
@@ -218,7 +219,7 @@ export const BookDetailHeaderGroup: React.FunctionComponent<{
                     />
                 )}
                 {showTranslateButton && (
-                    <TranslateButton
+                    <DownloadToBloomButton
                         book={props.book}
                         fullWidth={fullWidthButtons}
                         contextLangIso={props.contextLangIso}

--- a/src/components/BookDetail/DownloadToBloomButton.tsx
+++ b/src/components/BookDetail/DownloadToBloomButton.tsx
@@ -1,0 +1,160 @@
+// this engages a babel macro that does cool emotion stuff (like source maps). See https://emotion.sh/docs/babel-macros
+import css from "@emotion/css/macro";
+// these two lines make the css prop work on react elements
+import { jsx } from "@emotion/core";
+/** @jsx jsx */
+
+import React, { useState } from "react";
+import Button from "@material-ui/core/Button";
+import { commonUI } from "../../theme";
+import { FormattedMessage } from "react-intl";
+import { DownloadPreflightDialog } from "./DownloadPreflightDialog";
+import { useStorageState } from "react-storage-hooks";
+import { DownloadingShellbookDialog } from "./DownloadingShellbookDialog";
+import { Book } from "../../model/Book";
+import { useTheme } from "@material-ui/core";
+import { useLocation } from "react-router-dom";
+import { getTranslateIcon, TranslateButton } from "./TranslateButton";
+import { GetTemplateButton } from "./GetTemplateButton";
+
+interface ITranslateButtonProps {
+    book: Book;
+    contextLangIso?: string; // if we know the user is working with books in a particular language, this tells which one.
+    fullWidth?: boolean;
+}
+
+// This is the root button that downloads a book to Bloom Editor. Usually it reads "Translate this into your language"
+// but this does not make sense for template books so that has a different wording. Allow room for the "Get this Template"
+// version to be considerably higher than the usual one.
+// Note: if investigating history, be aware that most of this code was refactored from the TranslateButton, which
+// used to be the only version.
+export const DownloadToBloomButton: React.FunctionComponent<ITranslateButtonProps> = (
+    props
+) => {
+    const theme = useTheme();
+    const [preflightDialogOpen, setPreflightDialogOpen] = useState(false);
+    const [downloadingDialogOpen, setDownloadingDialogOpen] = useState(false);
+    const [
+        dontShowPreflightAgain,
+        setDontShowPreflightAgain,
+    ] = useStorageState<boolean>(
+        localStorage,
+        "dont-show-download-preflight-dialog",
+        false
+    );
+
+    // Ideally, this would be defined at some higher level and I could just use it here.
+    // But since it uses a hook, that greatly limits our ability to extract it.
+    // It didn't seem worth adding a whole new context provider.
+    const inCreate =
+        useLocation().pathname.toLowerCase().indexOf("create") > -1;
+
+    // This set of three properties controls how the translate version is different
+    // from the template version. If it gets any more complicated, we should create
+    // something to encapsulate the variations. For example, we might give each option
+    // a single function that returns {startButton, content, buttonHeight}, or if it
+    // gets still more complicated, a class that each button can subclass. But it doesn't
+    // seem quite worth it yet.
+
+    // We show drastically different content on the button if the book is a template,
+    // since it makes no sense to translate a template.
+    const isTemplate = props.book.suitableForMakingShells;
+
+    // This is the value of the startIcon property built into the material UI
+    // Button. It works well for laying out the TranslateButton and lets us
+    // exactly preserve the previous behavior we were happy with.
+    // Unfortunately it doesn't work at all for the TemplateButton layout, so we
+    // leave it undefined and insert the icon manually into the proper place in the
+    // layout. We could do the same for TranslateButton, but I'd rather not mess
+    // with a layout that isn't broken.
+    const startButton = isTemplate
+        ? undefined
+        : getTranslateIcon(theme, isTemplate);
+
+    // Main content of the two versions of the button.
+    const content = isTemplate ? (
+        <GetTemplateButton inCreate={inCreate} />
+    ) : (
+        <TranslateButton />
+    );
+
+    // The detailViewMainButtonHeight is way too small for the template version of the button.
+    // But an explicit height has to be sufficient even for translations, since the button
+    // will happily overflow its text out of the button onto other elements. And an explicit
+    // height that is OK for English in the wide configuration is a lot more than we need
+    // when the button has its own entire row on small screens, and the long text flows into
+    // fewer lines. So for template buttons I'm just letting the content dictate the size.
+    const buttonHeight = isTemplate
+        ? "initial"
+        : commonUI.detailViewMainButtonHeight;
+
+    return (
+        <React.Fragment>
+            <Button
+                variant="outlined"
+                color="secondary"
+                size="large"
+                css={css`
+                    /*don't do this. When the READ button is hidden, this will make it not align with the top
+                margin-top: 16px !important;*/
+                    width: ${props.fullWidth
+                        ? "100%"
+                        : commonUI.detailViewMainButtonWidth};
+                    height: ${buttonHeight};
+                    display: flex;
+                    float: right;
+                    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
+                        0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+                        0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+                `}
+                startIcon={startButton}
+                onClick={() => {
+                    props.book
+                        .checkCountryPermissions("downloadShell")
+                        .then((otherCountryRequired) => {
+                            if (otherCountryRequired) {
+                                alert(
+                                    `Sorry, the uploader of this book has restricted shellbook download to ${otherCountryRequired}`
+                                );
+                            } else {
+                                if (dontShowPreflightAgain) {
+                                    setDownloadingDialogOpen(true);
+                                } else {
+                                    setPreflightDialogOpen(true);
+                                }
+                            }
+                        });
+                }}
+            >
+                {content}
+            </Button>
+            <DownloadPreflightDialog
+                book={props.book}
+                open={preflightDialogOpen}
+                close={(
+                    doDownload: boolean,
+                    dontShowPreflightAgainFromDialog: boolean
+                ) => {
+                    // We shouldn't need to set this here because it has already been set in the dialog.
+                    // But apparently two components cannot both actively monitor the same useStorageState
+                    // variable at the same time. Without this hack, if the user checks the box to not show
+                    // the dialog again, it keeps showing up through the end of that session.
+                    setDontShowPreflightAgain(dontShowPreflightAgainFromDialog);
+                    setPreflightDialogOpen(false);
+                    if (doDownload) {
+                        setDownloadingDialogOpen(true);
+                    }
+                }}
+                contextLangIso={props.contextLangIso}
+            ></DownloadPreflightDialog>
+            <DownloadingShellbookDialog
+                book={props.book}
+                open={downloadingDialogOpen}
+                close={() => {
+                    setDownloadingDialogOpen(false);
+                }}
+                contextLangIso={props.contextLangIso}
+            ></DownloadingShellbookDialog>
+        </React.Fragment>
+    );
+};

--- a/src/components/BookDetail/GetTemplateButton.tsx
+++ b/src/components/BookDetail/GetTemplateButton.tsx
@@ -1,0 +1,77 @@
+// this engages a babel macro that does cool emotion stuff (like source maps). See https://emotion.sh/docs/babel-macros
+import css from "@emotion/css/macro";
+// these two lines make the css prop work on react elements
+import { jsx } from "@emotion/core";
+/** @jsx jsx */
+
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { ReactComponent as TemplateIcon } from "../../assets/Template.svg";
+import { useTheme } from "@material-ui/core";
+import { commonUI } from "../../theme";
+
+// This the parts of DownloadToBloomButton that are unique to templates (as opposed to books to translate).
+export const GetTemplateButton: React.FunctionComponent<{
+    inCreate: boolean;
+}> = (props) => {
+    const theme = useTheme();
+    return (
+        <React.Fragment>
+            <div
+                css={css`
+                    display: flex;
+                    flex-direction: column;
+                    margin-top: 5px;
+                    margin-bottom: 8px;
+                `}
+            >
+                <div
+                    css={css`
+                        display: flex;
+                        margin-bottom: 10px;
+                    `}
+                >
+                    <TemplateIcon
+                        fill={
+                            props.inCreate
+                                ? theme.palette.primary.main
+                                : commonUI.colors.bloomBlue
+                        }
+                    />
+                    <div
+                        css={css`
+                            text-transform: initial;
+                            font-weight: normal;
+                            font-size: 14pt;
+                            line-height: 1.2;
+                            margin-left: 20px;
+                            margin-top: 10px; // roughly centers in icon height
+                        `}
+                    >
+                        <FormattedMessage
+                            id="book.detail.getTemplateButton.getThis"
+                            defaultMessage="Get this Template"
+                            values={{
+                                emphasis: (str: string) => <em>{str}</em>,
+                            }}
+                        />
+                    </div>
+                </div>
+                <div
+                    css={css`
+                        font-size: 9pt;
+                        line-height: 1.1;
+                        text-transform: initial;
+                        margin-top: 5px;
+                        text-align: start;
+                    `}
+                >
+                    <FormattedMessage
+                        id="book.detail.getTemplateButton.download"
+                        defaultMessage='The template book will be downloaded and installed. You can start a book with this template, or add any of its template pages from the "Add Page" dialog box from any book.'
+                    />
+                </div>
+            </div>
+        </React.Fragment>
+    );
+};

--- a/src/components/BookDetail/TranslateButton.tsx
+++ b/src/components/BookDetail/TranslateButton.tsx
@@ -4,155 +4,65 @@ import css from "@emotion/css/macro";
 import { jsx } from "@emotion/core";
 /** @jsx jsx */
 
-import React, { useState } from "react";
-import Button from "@material-ui/core/Button";
-import { ReactComponent as TranslationIcon } from "../../assets/Translation.svg";
-import { commonUI } from "../../theme";
+import React from "react";
 import { FormattedMessage } from "react-intl";
-import { DownloadPreflightDialog } from "./DownloadPreflightDialog";
-import { useStorageState } from "react-storage-hooks";
-import { DownloadingShellbookDialog } from "./DownloadingShellbookDialog";
-import { Book } from "../../model/Book";
-import { useTheme } from "@material-ui/core";
-import { useLocation } from "react-router-dom";
+import { ReactComponent as TranslationIcon } from "../../assets/Translation.svg";
+import { Theme } from "@material-ui/core";
+import { commonUI } from "../../theme";
 
-interface ITranslateButtonProps {
-    book: Book;
-    contextLangIso?: string; // if we know the user is working with books in a particular language, this tells which one.
-    fullWidth?: boolean;
-}
-
-export const TranslateButton: React.FunctionComponent<ITranslateButtonProps> = (
-    props
-) => {
-    const theme = useTheme();
-    const [preflightDialogOpen, setPreflightDialogOpen] = useState(false);
-    const [downloadingDialogOpen, setDownloadingDialogOpen] = useState(false);
-    const [
-        dontShowPreflightAgain,
-        setDontShowPreflightAgain,
-    ] = useStorageState<boolean>(
-        localStorage,
-        "dont-show-download-preflight-dialog",
-        false
-    );
-
-    // Ideally, this would be defined at some higher level and I could just use it here.
-    // But since it uses a hook, that greatly limits our ability to extract it.
-    // It didn't seem worth adding a whole new context provider.
-    const inCreate =
-        useLocation().pathname.toLowerCase().indexOf("create") > -1;
-
+// This file used to be the whole DownloadToBloomButton. Then we added the option of a GetTemplateButton
+// when the book to be downloaded is a template. Now this is just the bits that are unique to non-templates.
+export const TranslateButton: React.FunctionComponent = (props) => {
     return (
         <React.Fragment>
-            <Button
-                variant="outlined"
-                color="secondary"
-                size="large"
+            <div
                 css={css`
-                    /*don't do this. When the READ button is hidden, this will make it not align with the top
-                margin-top: 16px !important;*/
-                    width: ${props.fullWidth
-                        ? "100%"
-                        : commonUI.detailViewMainButtonWidth};
-                    height: ${commonUI.detailViewMainButtonHeight};
                     display: flex;
-                    float: right;
-                    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
-                        0px 2px 2px 0px rgba(0, 0, 0, 0.14),
-                        0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+                    flex-direction: column;
                 `}
-                startIcon={
-                    <TranslationIcon
-                        fill={
-                            inCreate
-                                ? theme.palette.primary.main
-                                : commonUI.colors.bloomBlue
-                        }
-                    />
-                }
-                onClick={() => {
-                    props.book
-                        .checkCountryPermissions("downloadShell")
-                        .then((otherCountryRequired) => {
-                            if (otherCountryRequired) {
-                                alert(
-                                    `Sorry, the uploader of this book has restricted shellbook download to ${otherCountryRequired}`
-                                );
-                            } else {
-                                if (dontShowPreflightAgain) {
-                                    setDownloadingDialogOpen(true);
-                                } else {
-                                    setPreflightDialogOpen(true);
-                                }
-                            }
-                        });
-                }}
             >
                 <div
                     css={css`
-                        display: flex;
-                        flex-direction: column;
+                        text-transform: initial;
+                        font-weight: normal;
+                        font-size: 14pt;
+                        line-height: 1.2;
                     `}
                 >
-                    <div
-                        css={css`
-                            text-transform: initial;
-                            font-weight: normal;
-                            font-size: 14pt;
-                            line-height: 1.2;
-                        `}
-                    >
-                        <FormattedMessage
-                            id="book.detail.translateButton.translate"
-                            defaultMessage="Translate into <emphasis>your</emphasis> language!"
-                            values={{
-                                emphasis: (str: string) => <em>{str}</em>,
-                            }}
-                        />
-                    </div>
-                    <div
-                        css={css`
-                            font-size: 9pt;
-                            line-height: 1.1;
-                            text-transform: initial;
-                            margin-top: 5px;
-                        `}
-                    >
-                        <FormattedMessage
-                            id="book.detail.translateButton.download"
-                            defaultMessage="Download into Bloom Editor"
-                        />
-                    </div>
+                    <FormattedMessage
+                        id="book.detail.translateButton.translate"
+                        defaultMessage="Translate into <emphasis>your</emphasis> language!"
+                        values={{
+                            emphasis: (str: string) => <em>{str}</em>,
+                        }}
+                    />
                 </div>
-            </Button>
-            <DownloadPreflightDialog
-                book={props.book}
-                open={preflightDialogOpen}
-                close={(
-                    doDownload: boolean,
-                    dontShowPreflightAgainFromDialog: boolean
-                ) => {
-                    // We shouldn't need to set this here because it has already been set in the dialog.
-                    // But apparently two components cannot both actively monitor the same useStorageState
-                    // variable at the same time. Without this hack, if the user checks the box to not show
-                    // the dialog again, it keeps showing up through the end of that session.
-                    setDontShowPreflightAgain(dontShowPreflightAgainFromDialog);
-                    setPreflightDialogOpen(false);
-                    if (doDownload) {
-                        setDownloadingDialogOpen(true);
-                    }
-                }}
-                contextLangIso={props.contextLangIso}
-            ></DownloadPreflightDialog>
-            <DownloadingShellbookDialog
-                book={props.book}
-                open={downloadingDialogOpen}
-                close={() => {
-                    setDownloadingDialogOpen(false);
-                }}
-                contextLangIso={props.contextLangIso}
-            ></DownloadingShellbookDialog>
+                <div
+                    css={css`
+                        font-size: 9pt;
+                        line-height: 1.1;
+                        text-transform: initial;
+                        margin-top: 5px;
+                    `}
+                >
+                    <FormattedMessage
+                        id="book.detail.translateButton.download"
+                        defaultMessage="Download into Bloom Editor"
+                    />
+                </div>
+            </div>
         </React.Fragment>
     );
 };
+
+export function getTranslateIcon(theme: Theme, inCreate: boolean) {
+    return (
+        <TranslationIcon
+            fill={
+                inCreate
+                    ? theme.palette.primary.main
+                    : commonUI.colors.bloomBlue
+            }
+        />
+    );
+}

--- a/src/connection/LibraryQueryHooks.ts
+++ b/src/connection/LibraryQueryHooks.ts
@@ -194,7 +194,7 @@ export function useGetPhashMatchingRelatedBooks(
 export const bookDetailFields =
     "title,allTitles,baseUrl,bookOrder,inCirculation,license,licenseNotes,summary,copyright,harvestState,harvestLog," +
     "tags,pageCount,phashOfFirstContentImage,show,credits,country,features,internetLimits," +
-    "librarianNote,uploader,langPointers,importedBookSourceUrl,downloadCount," +
+    "librarianNote,uploader,langPointers,importedBookSourceUrl,downloadCount,suitableForMakingShells," +
     "harvestStartedAt,bookshelves,publisher,originalPublisher,keywords,bookInstanceId,brandingProjectName,edition";
 export function useGetBookDetail(bookId: string): Book | undefined | null {
     const { response, loading, error } = useAxios({

--- a/src/localization/Code Strings.json
+++ b/src/localization/Code Strings.json
@@ -170,6 +170,14 @@
         "description": "",
         "message": "How to translate"
     },
+    "book.detail.getTemplateButton.getThis": {
+        "description": "Get in the sense of start a process to download it.",
+        "message": "Get this Template"
+    },
+    "book.detail.getTemplateButton.download": {
+        "description": "",
+        "message": "The template book will be downloaded and installed. You can start a book with this template, or add any of its template pages from the \"Add Page\" dialog box from any book."
+    },
     "book.detail.translateButton.translate": {
         "description": "",
         "message": "Translate into <emphasis>your</emphasis> language!"

--- a/src/model/Book.ts
+++ b/src/model/Book.ts
@@ -75,6 +75,7 @@ export class Book {
     public bookInstanceId: string = "";
     public internetLimits: IInternetLimits = {};
     public brandingProjectName = "";
+    public suitableForMakingShells = false; // that is, the book is a template.
 
     // things that can be edited on the site are observable so that the rest of the UI will update if they are changed.
     public title: string = "";


### PR DESCRIPTION
A variant of TranslateButton for templates.
The common functionality is moved to DownloadToBloomButton.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/313)
<!-- Reviewable:end -->
