### PR TITLE
Easier subcollection embedding, Phase 2 (BL-9720)

### DIFF
--- a/src/components/EmbeddingHost.test.ts
+++ b/src/components/EmbeddingHost.test.ts
@@ -1,0 +1,31 @@
+import { doesNameMatchPattern } from "./EmbeddingHost";
+
+const trueCases: string[][] = [
+    ["one", "one"],
+    ["one*", "one"],
+    ["one*", "one two"],
+    ["one", "ONE"],
+    ["ONE", "one"],
+    ["*", "one"],
+];
+test.each(trueCases)(
+    "doesNameMatchPattern returns true for valid patterns: #%# (%s, %s)", // %# is the index. The first %s consumes the 1st argument, and the 2nd %s consumes the 2nd argument
+    (pattern, collectionName) => {
+        const result = doesNameMatchPattern(collectionName, pattern);
+
+        expect(result).toBeTruthy();
+    }
+);
+
+const falseCases: string[][] = [
+    ["two*", "one two"],
+    ["one", "one two"],
+];
+test.each(falseCases)(
+    "doesNameMatchPattern returns false for non-matching patterns: : #%# (%s, %s)",
+    (pattern, collectionName) => {
+        const result = doesNameMatchPattern(collectionName, pattern);
+
+        expect(result).toBeFalsy();
+    }
+);


### PR DESCRIPTION
Allows patterns to be specified in contentful which control which collections are allowed to be embedded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/322)
<!-- Reviewable:end -->
