### PR TITLE
Handle trailing * for tag filter values (BL-10838)

### DIFF
--- a/src/connection/LibraryQueryHooks.test.ts
+++ b/src/connection/LibraryQueryHooks.test.ts
@@ -292,3 +292,18 @@ it("builds proper parse query for recursive anyOfThese field", () => {
         '{"count":1,"limit":0,"where":{"tags":"bookshelf:first","inCirculation":{"$in":[true,null]},"draft":{"$in":[false,null]},"$or":[{"tags":"bookshelf:second"},{"$or":[{"tags":"bookshelf:third"}]}]}}'
     );
 });
+
+it("builds proper parse query for tag field ending with *", () => {
+    const inputFilter: IFilter = {
+        otherTags: "list:Bible*",
+    };
+    const result = constructParseBookQuery(
+        { count: 1, limit: 0 },
+        inputFilter,
+        []
+    );
+    const resultString = JSON.stringify(result);
+    expect(resultString).toBe(
+        '{"count":1,"limit":0,"where":{"tags":{"$regex":"^list:Bible"},"inCirculation":{"$in":[true,null]},"draft":{"$in":[false,null]}}}'
+    );
+});

--- a/src/connection/LibraryQueryHooks.ts
+++ b/src/connection/LibraryQueryHooks.ts
@@ -1293,7 +1293,13 @@ export function constructParseBookQuery(
     }
     // Now we need to assemble topicsAll and tagParts
     if (tagsAll.length === 1 && tagParts.length === 0) {
-        params.where.tags = tagsAll[0];
+        if (tagsAll[0].endsWith("*")) {
+            // Anchor the regex and leave it case sensitive.  This is the most efficient form of regex.
+            const tagPrefix = tagsAll[0].substring(0, tagsAll[0].length - 1);
+            params.where.tags = { $regex: "^" + processRegExp(tagPrefix) };
+        } else {
+            params.where.tags = tagsAll[0];
+        }
     } else {
         if (tagsAll.length) {
             // merge topicsAll into tagsAll
@@ -1407,7 +1413,6 @@ export function constructParseBookQuery(
             params.where.$or.push(pbq.where);
         }
     }
-
     return params;
 }
 


### PR DESCRIPTION
This will allow matching on the beginnings of tag values for filters
coming from Contentful, replacing the obsolete regex matching on
bookshelf values.  (which always applied but was needed for only a
handful of parent collections)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/403)
<!-- Reviewable:end -->
