### PR TITLE
BL-10888 Don't cut off "Languages"

### DIFF
--- a/src/components/LanguageGroup.tsx
+++ b/src/components/LanguageGroup.tsx
@@ -214,6 +214,7 @@ export const LanguageGroup: React.FunctionComponent = () => {
                                 <div
                                     css={css`
                                         margin-top: 4px;
+                                        line-height: 1em;
                                     `}
                                 >
                                     <FormattedMessage


### PR DESCRIPTION
*  Keep skinny or mobile brower from cutting off
    "Languages"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/410)
<!-- Reviewable:end -->
