### PR TITLE
Fix overly lazy loading of book groups (BL-10676)

### DIFF
--- a/src/components/BookGroup.tsx
+++ b/src/components/BookGroup.tsx
@@ -44,14 +44,31 @@ export function useGetResponsiveBookGroupTopMargin(): number {
 }
 
 export const BookGroup: React.FunctionComponent<IProps> = (props) => {
+    const documentWidth =
+        document.documentElement.clientWidth ||
+        document.body.clientWidth ||
+        window.innerWidth;
+    const cardSpec = useBookCardSpec();
+    // Enhance: figure out how to get a more accurate value for availableWidth, both by a
+    // better element width than documentWidth provides for the BookGroup element and by a
+    // better value of the padding applied to the element.
+    const availableWidth = documentWidth - cardSpec.cardSpacingPx; // approximate accounting for padding
+    // An approximate (but fairly accurate) cards per row measurement is needed to prevent overly
+    // lazy behavior in some cases.  See https://issues.bloomlibrary.org/youtrack/issue/BL-10676.
+    const cardsPerRow = Math.max(
+        1, // ensure cardsPerRow doesn't end up as 0, with a divide by zero crash below!
+        Math.floor(
+            availableWidth / (cardSpec.cardWidthPx + cardSpec.cardSpacingPx)
+        )
+    );
+
     // typically props.rows, if large, is intended as a maximum; very often the real size is
     // much less. We get less gigantic scroll bar ranges by limiting it.
     let rowCount = Math.min(props.rows ?? 1, 5);
     if (props.predeterminedBooks && props.rows !== 1) {
-        rowCount = Math.ceil(props.predeterminedBooks.length / 5); // still rough, but better than just using the max.
+        rowCount = Math.ceil(props.predeterminedBooks.length / cardsPerRow); // still rough, but better than just using the max.
     }
 
-    const cardSpec = useBookCardSpec();
     // note, if the number of cards is too small to fill up those rows, this will expect
     // to be taller than it is, but then when it is replaced by the actual content, the
     // scrollbar will adjust, so no big deal?


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/416)
<!-- Reviewable:end -->
