### PR TITLE
Get Preferred Languages button working again (BL-11627)

### DIFF
--- a/src/components/appHosted/AppHostedLanguageGroup.tsx
+++ b/src/components/appHosted/AppHostedLanguageGroup.tsx
@@ -55,7 +55,6 @@ export const AppHostedLanguageGroup: React.FunctionComponent = () => {
     const preferredLangsString: string = cookies["preferredLanguages"];
     const [showAll, setShowAll] = useState(false);
     const [showPreferredLangs, setShowPreferredLangs] = useState(true);
-    const [buttondown, setButtonDown] = useState(false);
     const [preferredLangs, preferredLangCodes] = useMemo(() => {
         const preferredCodes = preferredLangsString
             ? preferredLangsString.split(",")
@@ -144,13 +143,7 @@ export const AppHostedLanguageGroup: React.FunctionComponent = () => {
                         // presumably not currently interested in the ones that were already at the top
                         // of the list.)
                         // See BL-11575.
-                        // When the user presses a language button while the input has focus, if we're not
-                        // careful the loss of focus takes effect and the button moves before the user
-                        // can complete the click/tap. So while a button is pressed we go on not showing
-                        // this block. (It looks as if there could be some flicker between when showPreferredLangs
-                        // is set false and when buttonDown gets set true, but somehow React is smart enough
-                        // that this is not noticeable and does not interfere with the click.)
-                        showPreferredLangs && !buttondown && (
+                        showPreferredLangs && (
                             <>
                                 <h3>
                                     <FormattedMessage
@@ -183,12 +176,6 @@ export const AppHostedLanguageGroup: React.FunctionComponent = () => {
                                             primaryTextColorOverride="white"
                                             secondaryTextColorOverride="#FFFFFFE5" // E5 = 90%
                                             larger={true}
-                                            onMouseDown={() =>
-                                                setButtonDown(true)
-                                            }
-                                            onMouseUp={() =>
-                                                setButtonDown(false)
-                                            }
                                             targetPrefix={
                                                 "/" +
                                                 appHostedSegment +


### PR DESCRIPTION
Bizarre. Reverses what I thought was the key part of allowing lang button press while input has focus. But that fix was in the wrong place: I put it on the preferred languages buttons, not the regular ones. Hypothesis: what really fixed the prior problem was putting a meaningful ID on the main language buttons, so even after restoring preferred languages, the same DOM button is still around to process the mouse-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/476)
<!-- Reviewable:end -->
