### PR TITLE
Fix scroll to top when filtering language for real device (BL-11687)

### DIFF
--- a/src/components/appHosted/AppHostedLanguageGroup.tsx
+++ b/src/components/appHosted/AppHostedLanguageGroup.tsx
@@ -281,10 +281,14 @@ export const AppHostedLanguageGroup: React.FunctionComponent = () => {
                 (window as any).ParentProxy?.postMessage("close_keyboard");
             }
         }
+    };
+
+    const handleSearchTermChange = () => {
         document
             .getElementById("app-hosted-more-languages-container")
             ?.scrollTo(0, 0);
     };
+
     // This is working around the fact that our typedefs do not know that GetRootPropsOptions
     // is allowed to have a role property. The effect is to prevent the root div that contains
     // the type-ahead box getting the combobox role and related aria declarations that cause
@@ -433,6 +437,7 @@ export const AppHostedLanguageGroup: React.FunctionComponent = () => {
                                         {...getInputProps({
                                             onKeyPress: (e) =>
                                                 handleKeyPress(e),
+                                            onChange: handleSearchTermChange,
                                         })}
                                         onFocus={() =>
                                             setShowPreferredLangs(false)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomlibrary2/480)
<!-- Reviewable:end -->
