### PR TITLE
BL-11881 Add subheader to stats card label

### DIFF
--- a/src/components/statistics/StatsOverviewScreen.tsx
+++ b/src/components/statistics/StatsOverviewScreen.tsx
@@ -105,6 +105,17 @@ export const StatsOverviewScreen: React.FunctionComponent<IStatsPageProps> = (
                     id="stats.people.reached"
                     defaultMessage="People Reached Digitally"
                 />
+                {/* Need a separate div to put it below the message above. */}
+                <div
+                    css={css`
+                        font-size: 8pt;
+                    `}
+                >
+                    <FormattedMessage
+                        id="stats.people.reached.subheader"
+                        defaultMessage="(does not count the vast majority of readers, who use paper)"
+                    />
+                </div>
             </StatsCard>
             <StatsCard
                 //  I don't think we're ready for translation on this one yet...
@@ -128,7 +139,7 @@ export const StatsOverviewScreen: React.FunctionComponent<IStatsPageProps> = (
                     },
                     {
                         label: i18n.formatMessage({
-                            id: "books-with-analytics",
+                            id: "stats.booksWithAnalytics",
                             defaultMessage: "Books with Analytics",
                         }),
                         value: stats.booksWithAnalytics,

--- a/src/localization/Stats Strings.json
+++ b/src/localization/Stats Strings.json
@@ -151,6 +151,18 @@
         "description": "",
         "message": "Comprehension Questions"
     },
+    "stats.locations-city-table": {
+        "message": "Locations: City Table",
+        "description": ""
+    },
+    "stats.locations-country-map": {
+        "message": "Locations: Country Map",
+        "description": ""
+    },
+    "stats.locations-country-table": {
+        "message": "Locations: Country Table",
+        "description": ""
+    },
     "stats.people.reached": {
         "message": "People Reached Digitally",
         "description": "A header for a card showing statistics on how many people have been reached with these books"
@@ -158,6 +170,10 @@
     "stats.people.reached.info": {
         "message": "Will overcount when the same person reads one of these books via multiple devices or applications. Will undercount when firewalls or lack of connectivity permanently prevent analytics connections.",
         "description": ""
+    },
+    "stats.people.reached.subheader": {
+        "message": "(does not count the vast majority of readers, who use paper)",
+        "description": "Explanation under 'People Reached Digitally'"
     },
     "stats.reads": {
         "description": "",


### PR DESCRIPTION
* explanation for "people reached digitally"
* the other change matches the l10n key for a string to
   the one already in the json file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomLibrary2/495)
<!-- Reviewable:end -->
