### PR TITLE
fix BL-11469 context language lost with "all book" layout

### DIFF
--- a/src/model/Collections.tsx
+++ b/src/model/Collections.tsx
@@ -13,6 +13,7 @@ import { getLocalizedCollectionLabel } from "../localization/CollectionLabel";
 import { appHostedSegment } from "../components/appHosted/AppHostedUtils";
 import { generateCollectionFromFilters } from "../components/CollectionSubsetPage";
 import { isFacetedSearchString } from "../connection/LibraryQueryHooks";
+import { getContextLangTagFromLanguageSegment } from "../components/Routes";
 
 /* From original design: Each collection has
     id
@@ -217,6 +218,11 @@ export function useGetCollection(
     }
 
     if (collection) {
+        // e.g. https://bloomlibrary.org/language:zh-CN should have context language zh-CN
+        collection.contextLangTag = getContextLangTagFromLanguageSegment(
+            collection.urlKey
+        );
+
         // Cache the raw collections from Contentful, before any custom filters are applied to it
         // 1) What the cache is doing for is saving us from retrieving collection definitions from contentful.
         //    The custom filters are irrelevant to that stage, so they need not be included in the cache key


### PR DESCRIPTION
In general, if a collection is a language collection, set the context language to that language (duh)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomLibrary2/518)
<!-- Reviewable:end -->
