### PR TITLE
Changes since download-for-edit version of Desktop is now 6.0 (BL-13349)

### DIFF
--- a/src/components/BookDetail/ArtifactHelper.ts
+++ b/src/components/BookDetail/ArtifactHelper.ts
@@ -79,9 +79,9 @@ function getBookOrderUrl(book: Book, forEdit: boolean) {
         // The earliest version that we plan to check this for is 5.5, so it doesn't really
         // matter what version we put earlier than that for normal downloads, which are handled
         // by all the versions that do this check.
-        // We do need 5.7 to handle the forEdit parameter, so we will pass that and retrofit at least
+        // We do need 6.0 to handle the forEdit parameter, so we will pass that and retrofit at least
         // 5.5 and 5.6 to do the check.
-        const minVersion = forEdit ? 5.7 : 4.8;
+        const minVersion = forEdit ? 6.0 : 4.8;
 
         const forEditPart = forEdit
             ? `&forEdit=true&database-id=${book.id}`

--- a/src/components/BookDetail/BookOwnerControlsBox.tsx
+++ b/src/components/BookDetail/BookOwnerControlsBox.tsx
@@ -25,8 +25,8 @@ import {
     useGetPermissions,
 } from "../../connection/LibraryQueryHooks";
 
-// This should become true or just be removed once 5.7 is shipping.
-// The controls it hides require 5.7, so we don't want ordinary users to see them until then.
+// This should become true or just be removed once 6.0 is shipping.
+// The controls it hides require 6.0, so we don't want ordinary users to see them until then.
 // We do want to be able to test this on our dev and alpha sites, though.
 const allowDownloadForEditing =
     window.location.hostname.startsWith("alpha") ||
@@ -203,7 +203,7 @@ export const BookOwnerControlsBox: React.FunctionComponent<{
                                 <FormattedMessage
                                     id={"book.detail.getForEditBookNotice"}
                                     defaultMessage={
-                                        "If necessary, we can give you the book to edit in Bloom. You must first have Bloom 5.7 or greater installed ({downloadLink})."
+                                        "If necessary, we can give you the book to edit in Bloom. You must first have Bloom 6.0 or greater installed ({downloadLink})."
                                     }
                                     values={{
                                         downloadLink: (

--- a/src/localization/Code Strings.json
+++ b/src/localization/Code Strings.json
@@ -270,7 +270,7 @@
         "description": ""
     },
     "book.detail.getForEditBookNotice": {
-        "message": "If necessary, we can give you the book to edit in Bloom. You must first have Bloom 5.7 or greater installed ({downloadLink}).",
+        "message": "If necessary, we can give you the book to edit in Bloom. You must first have Bloom 6.0 or greater installed ({downloadLink}).",
         "description": "{downloadLink} is a link to the Bloom download page. Leave it exactly as it is except for putting it in the right place; don't translate it here."
     },
     "book.detail.downloadLink": {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomLibrary2/548)
<!-- Reviewable:end -->
