### PR TITLE
Display "Unlisted Language (qaa)", not blank in language grid (BL-14280)

### DIFF
--- a/src/components/AggregateGrid/AggregateGridPage.tsx
+++ b/src/components/AggregateGrid/AggregateGridPage.tsx
@@ -363,6 +363,14 @@ export function getLangTagDataForIrregularLangCode(
             langTagData.region = tagData.region;
             langTagData.regionname = tagData.regionname;
         }
+    } else if (code === "qaa") {
+        // Note that tags like qaa-x-Chalchiteko have already had their names set above.
+        langTagData.name = "Unlisted Language (qaa)";
+    } else if (!langTagData.name) {
+        console.error(
+            `We could not determine a name for language code ${code}`
+        );
+        langTagData.name = `Unknown Language (${code})`;
     }
     return langTagData;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomLibrary2/581)
<!-- Reviewable:end -->
