### PR TITLE
Use bookHash instead of phash where possible to link books (BL-14980)

### DIFF
--- a/src/components/BookDetail/BookDetailHeaderGroup.tsx
+++ b/src/components/BookDetail/BookDetailHeaderGroup.tsx
@@ -44,9 +44,18 @@ export const BookDetailHeaderGroup: React.FunctionComponent<{
         phash && phash.trim() && phash.trim() !== "null"
             ? phash.trim()
             : "Not A Valid Phash";
-    const answer = useGetBookCountRaw({
-        search: "phash:" + sanitizedPhashOfFirstContentImage,
-    });
+    const bookHash = props.book.bookHashFromImages;
+    const sanitizedBookHashFromImages =
+        bookHash && bookHash.trim() && bookHash.trim() !== "null"
+            ? bookHash.trim()
+            : null;
+    const searchCriteria = sanitizedBookHashFromImages
+        ? { search: "bookHash:" + sanitizedBookHashFromImages }
+        : { search: "phash:" + sanitizedPhashOfFirstContentImage };
+    // const searchCriteria = {
+    //     search: "phash:" + sanitizedPhashOfFirstContentImage,
+    // };
+    const answer = useGetBookCountRaw(searchCriteria);
     const countOfBooksWithMatchingPhash =
         getResultsOrMessageElement(answer).count - 1;
 
@@ -189,7 +198,11 @@ export const BookDetailHeaderGroup: React.FunctionComponent<{
                                                     `}
                                                     newTabIfEmbedded={true}
                                                     color="secondary"
-                                                    href={`/phash:${sanitizedPhashOfFirstContentImage}`}
+                                                    href={
+                                                        sanitizedBookHashFromImages
+                                                            ? `/bookHash:${sanitizedBookHashFromImages}`
+                                                            : `/phash:${sanitizedPhashOfFirstContentImage}`
+                                                    }
                                                 >
                                                     <FormattedMessage
                                                         id="book.detail.translations"

--- a/src/components/Grid/GridColumns.tsx
+++ b/src/components/Grid/GridColumns.tsx
@@ -316,6 +316,7 @@ export function getBookGridColumnsDefinitions(): IGridColumn[] {
         },
         { name: "pageCount", sortingEnabled: true },
         { name: "phashOfFirstContentImage", sortingEnabled: true },
+        { name: "bookHashFromImages", sortingEnabled: true },
         { name: "createdAt", sortingEnabled: true },
         { name: "updatedAt", sortingEnabled: true },
         {

--- a/src/connection/LibraryQueryHooks.ts
+++ b/src/connection/LibraryQueryHooks.ts
@@ -295,7 +295,7 @@ export function useGetPhashMatchingRelatedBooks(
 
 export const bookDetailFields =
     "title,allTitles,baseUrl,bookOrder,inCirculation,draft,license,licenseNotes,summary,copyright,harvestState,harvestLog," +
-    "tags,pageCount,phashOfFirstContentImage," +
+    "tags,pageCount,phashOfFirstContentImage,bookHashFromImages," +
     // show is in here in order to let us figure out L1, which is, sadly, not directly listed in Parse nor determinable from the langPointers
     "show," +
     "credits,country,features,internetLimits," +
@@ -391,7 +391,7 @@ interface IGridResult {
 export const gridBookKeys =
     "objectId,bookInstanceId," +
     "title,baseUrl,license,licenseNotes,inCirculation,draft,summary,copyright,harvestState," +
-    "harvestLog,harvestStartedAt,tags,pageCount,phashOfFirstContentImage,show,credits,country," +
+    "harvestLog,harvestStartedAt,tags,pageCount,phashOfFirstContentImage,bookHashFromImages,show,credits,country," +
     "features,internetLimits,librarianNote,uploader,langPointers,importedBookSourceUrl," +
     "downloadCount,publisher,originalPublisher,brandingProjectName,keywords,edition,rebrand,leveledReaderLevel," +
     "analytics_finishedCount,analytics_startedCount,analytics_shellDownloads";
@@ -675,6 +675,7 @@ export interface IBasicBookInfo {
     createdAt: string;
     country?: string;
     phashOfFirstContentImage?: string;
+    bookHashFromImages?: string;
     edition: string;
     draft?: boolean;
     inCirculation?: boolean;
@@ -690,7 +691,7 @@ export interface IBasicBookInfo {
 }
 
 const kFieldsOfIBasicBookInfo =
-    "title,baseUrl,objectId,langPointers,tags,features,lastUploaded,harvestState,harvestStartedAt,pageCount,phashOfFirstContentImage,allTitles,edition,draft,rebrand,inCirculation,show";
+    "title,baseUrl,objectId,langPointers,tags,features,lastUploaded,harvestState,harvestStartedAt,pageCount,phashOfFirstContentImage,bookHashFromImages,allTitles,edition,draft,rebrand,inCirculation,show";
 
 // uses the human "level:" tag if present, otherwise falls back to computedLevel
 export function getBestLevelStringOrEmpty(basicBookInfo: IBasicBookInfo) {
@@ -931,6 +932,7 @@ const facets = [
     "harvestState:",
     "country:",
     "phash:",
+    "bookHash:",
     "level:",
     "feature:",
     "originalPublisher:", // must come before "publisher:", since "originalPublisher:" includes the other as a substring
@@ -1244,6 +1246,9 @@ export function constructParseBookQuery(
                         facetValue
                     );
                     break;
+                case "bookHash":
+                    params.where.bookHashFromImages = facetValue;
+                    break;
                 case "harvestState":
                     params.where.harvestState = facetValue;
                     break;
@@ -1553,7 +1558,11 @@ export function constructParseBookQuery(
             params.where.$or.push(pbq.where);
         }
     }
-
+    // console.log(
+    //     `DEBUG constructParseBookQuery: params.where = ${JSON.stringify(
+    //         params.where
+    //     )}`
+    // );
     return params;
 }
 

--- a/src/model/Book.ts
+++ b/src/model/Book.ts
@@ -69,6 +69,7 @@ export class Book {
     public harvestLog: string[] = [];
     public harvestState: string = "";
     public phashOfFirstContentImage: string = "";
+    public bookHashFromImages: string = "";
     public bookInstanceId: string = "";
     public internetLimits: IInternetLimits = {};
     public brandingProjectName = "";
@@ -195,6 +196,12 @@ export class Book {
             this.phashOfFirstContentImage.indexOf("null") > -1
         )
             this.phashOfFirstContentImage = "";
+
+        if (
+            !this.bookHashFromImages ||
+            this.bookHashFromImages.indexOf("null") > -1
+        )
+            this.bookHashFromImages = "";
 
         // todo: parse out the dates, in this YYYY-MM-DD format (e.g. with )
         this.uploadDate = new Date(Date.parse(this.createdAt));

--- a/src/model/Collections.tsx
+++ b/src/model/Collections.tsx
@@ -332,8 +332,12 @@ function getFacetCollection(
             );
 
         case "phash":
-            // search collections are generated from a search string the user typed.
-            return makeVirtualCollectionForPHash(templateCollection, value);
+        case "bookHash":
+            return makeVirtualCollectionForHash(
+                templateCollection,
+                facet,
+                value
+            );
 
         default:
             throw Error(`Unknown facet: ${facet}`);
@@ -450,16 +454,17 @@ export function makeVirtualCollectionForSearch(
     return result;
 }
 
-export function makeVirtualCollectionForPHash(
+export function makeVirtualCollectionForHash(
     templateCollection: ICollection,
-    phash: string
+    facet: string,
+    value: string
 ): ICollection {
-    // review: would it be cleaner to make phash a top-level field in filter?
+    // review: would it be cleaner to make phash or bookHash a top-level field in filter?
     // Would require changes to the LibraryQueryHooks function for interpreting
     // filter. It's also remotely possible that losing the ability to type
-    // a phash: into the search box would be missed.
-    const filter = { search: "phash:" + phash };
-    const urlKey = "phash:" + phash;
+    // a phash: or bookHash: into the search box would be missed.
+    const filter = { search: `${facet}:${value}` };
+    const urlKey = `${facet}:${value}`;
     const result: ICollection = {
         ...templateCollection,
         filter,

--- a/src/model/DuplicateBookFilter.ts
+++ b/src/model/DuplicateBookFilter.ts
@@ -36,10 +36,13 @@ export function PreferBooksWithL1MatchingFocusLanguage_DuplicateBookFilter(
     languageInFocus?: string,
     markButDoNotRemove?: boolean
 ): IBasicBookInfo[] {
-    // use phash to get candidates for duplicates
+    // use bookHashFromImages (or phash if not available) to get candidates for duplicates
     const hashToBooks = new Map<string, IBasicBookInfo[]>();
     for (const book of books) {
         let hash = book.phashOfFirstContentImage;
+        if (book.bookHashFromImages) {
+            hash = book.bookHashFromImages;
+        }
         if (languageInFocus) {
             let titleInContextLang = getBookTitleInLanguageOrUndefined(
                 book,
@@ -138,12 +141,16 @@ export function PreferBooksWithL1MatchingFocusLanguage_DuplicateBookFilter(
 export function DefaultBookComparisonKeyIgnoringLanguages(
     book: IBasicBookInfo
 ): string | undefined {
-    const phash = book.phashOfFirstContentImage;
-    if (!phash) {
+    let hash = book.bookHashFromImages;
+    if (!hash) {
+        hash = book.phashOfFirstContentImage;
+    }
+    // if we don't have a hash, we can't reliably compare the book to others
+    if (!hash) {
         return undefined; // undefined indicates that we can't reliably do a comparison
     }
     const featureHash = HashStringArray(book.features.sort());
-    return phash + book.pageCount + featureHash + book.edition;
+    return hash + book.pageCount + featureHash + book.edition;
 }
 
 // based on https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript


### PR DESCRIPTION
phash is still used where bookHash has not yet been computed.  This could be changed once we've computed the bookHash for all 20K plus books.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomLibrary2/589)
<!-- Reviewable:end -->
